### PR TITLE
Svav/make python hub

### DIFF
--- a/recipes/python/python.inc
+++ b/recipes/python/python.inc
@@ -7,12 +7,12 @@ RECIPE_TYPES = "native machine"
 
 inherit autotools  make
 
-CROSS_DEPENDS = "native:python  native:python-lib libssl libz libreadline libffi zlib libcrypto libtermcap libm"
+CROSS_DEPENDS = "native:python  native:python-lib libssl libz libreadline libffi libcrypto libtermcap libm"
 CROSS_DEPENDS:native = ""
 DEPENDS += "${CROSS_DEPENDS}"
 
-DEPENDS_${PN}:machine += " libz libssl libreadline libffi zlib libcrypto libtermcap libm "
-RDEPENDS_${PN}:machine += "libz libssl libreadline libffi zlib libcrypto libtermcap libm "
+DEPENDS_${PN}:machine += " libz libssl libreadline libffi libcrypto libtermcap libm "
+RDEPENDS_${PN}:machine += "libz libssl libreadline libffi libcrypto libtermcap libm "
 
 SRC_URI = "http://www.python.org/ftp/python/${PV}/Python-${PV}.tar.bz2"
 # The machine needs to be patched

--- a/recipes/python/python.inc
+++ b/recipes/python/python.inc
@@ -1,0 +1,58 @@
+# -*- mode:python; -*-
+DESCRIPTION = "Python is a programming language that lets you work more quickly and integrate your systems more effectively."
+HOMEPAGE = "https://www.python.org/"
+LICENSE = "python"
+
+RECIPE_TYPES = "native machine"
+
+inherit autotools  make
+
+CROSS_DEPENDS = "native:python readline-dev openssl libssl  libz readline readline-dev libreadline libreadline-dev libffi zlib  libcrypto  libtermcap libm"
+CROSS_DEPENDS:native = ""
+DEPENDS += "${CROSS_DEPENDS}"
+
+DEPENDS_${PN}:machine += " libz openssl libssl  readline readline-dev libreadline libreadline-dev  libffi zlib  libcrypto libtermcap libm "
+RDEPENDS_${PN}:machine += " libz openssl libssl  readline libreadline  libffi zlib  libcrypto libtermcap libm "
+
+SRC_URI = "http://www.python.org/ftp/python/${PV}/Python-${PV}.tar.bz2"
+# The machine needs to be patched
+# http://www.trevorbowen.com/2013/10/07/cross-compiling-python-2-7-5-for-embedded-linux/
+# http://bugs.python.org/file31991/Python-2.7.5-xcompile.patch
+SRC_URI:>machine = " file://Python-2.7.5-xcompile.patch;striplevel=3"
+
+# Python is in caps!
+S = "${SRCDIR}/Python-${PV}"
+
+do_compile[prefuncs] += "${DO_COMPILE_COPY_NATIVE}"
+DO_COMPILE_COPY_NATIVE = ""
+DO_COMPILE_COPY_NATIVE:machine = "do_compile_copy_native"
+do_compile_copy_native() {
+    # Copy the native python into the machine src dir and rename to python_for_build
+    # which is expected by the patch
+    cp ${STAGE_DIR}/native/bin/python_native ${S}/python_for_build
+}
+
+EXTRA_OEMAKE_COMPILE:native="python Parser/pgen"
+EXTRA_OECONF:machine = "\
+  --disable-ipv6\
+  ac_cv_file__dev_ptmx=no\
+  ac_cv_file__dev_ptc=no\
+"
+
+# Make sure to include pgen and python from native into the package
+do_install[postfuncs] += "${DO_INSTALL_EXTRA_FILES}"
+DO_INSTALL_EXTRA_FILES = ""
+DO_INSTALL_EXTRA_FILES:native = "do_install_extra_files"
+do_install_extra_files () {
+	install -m 0755 ${S}/python \
+		${D}/bin/python_native
+	install -m 0755 ${S}/Parser/pgen \
+		${D}/bin/pgen_native
+}
+
+
+PACKAGES += "${PN}-lib"
+FILES_${PN}-lib = "/lib/python2.7/*"
+
+PACKAGES += "${PN}-lib-target"
+FILES_${PN}-lib-target = "/usr/lib/python2.7/*"

--- a/recipes/python/python.inc
+++ b/recipes/python/python.inc
@@ -52,7 +52,7 @@ do_install_extra_files () {
 
 
 PACKAGES += "${PN}-lib"
-FILES_${PN}-lib = "/lib/python2.7/*"
+FILES_${PN}-lib = "${base_libdir}/python2.7/*"
 
 PACKAGES += "${PN}-lib-target"
-FILES_${PN}-lib-target = "/usr/lib/python2.7/*"
+FILES_${PN}-lib-target = "${libdir}/python2.7/*"

--- a/recipes/python/python.inc
+++ b/recipes/python/python.inc
@@ -14,11 +14,13 @@ DEPENDS += "${CROSS_DEPENDS}"
 DEPENDS_${PN}:machine += " libz libssl libreadline libffi libcrypto libtermcap libm "
 RDEPENDS_${PN}:machine += "libz libssl libreadline libffi libcrypto libtermcap libm "
 
-SRC_URI = "http://www.python.org/ftp/python/${PV}/Python-${PV}.tar.bz2"
+SRC_URI = "http://www.python.org/ftp/python/${PV}/Python-${PV}.tar.xz"
 # The machine needs to be patched
+# Original patch from:
 # http://www.trevorbowen.com/2013/10/07/cross-compiling-python-2-7-5-for-embedded-linux/
 # http://bugs.python.org/file31991/Python-2.7.5-xcompile.patch
-SRC_URI:>machine = " file://Python-2.7.5-xcompile.patch;striplevel=3"
+# Note the patch has been modified!
+SRC_URI:>machine = " file://Python-${PV}-xcompile.patch;striplevel=3"
 
 # Python is in caps!
 S = "${SRCDIR}/Python-${PV}"

--- a/recipes/python/python.inc
+++ b/recipes/python/python.inc
@@ -7,7 +7,7 @@ RECIPE_TYPES = "native machine"
 
 inherit autotools  make
 
-CROSS_DEPENDS = "native:python libssl libz libreadline libffi zlib libcrypto libtermcap libm"
+CROSS_DEPENDS = "native:python  native:python-lib libssl libz libreadline libffi zlib libcrypto libtermcap libm"
 CROSS_DEPENDS:native = ""
 DEPENDS += "${CROSS_DEPENDS}"
 
@@ -23,15 +23,6 @@ SRC_URI:>machine = " file://Python-2.7.5-xcompile.patch;striplevel=3"
 # Python is in caps!
 S = "${SRCDIR}/Python-${PV}"
 
-do_compile[prefuncs] += "${DO_COMPILE_COPY_NATIVE}"
-DO_COMPILE_COPY_NATIVE = ""
-DO_COMPILE_COPY_NATIVE:machine = "do_compile_copy_native"
-do_compile_copy_native() {
-    # Copy the native python into the machine src dir and rename to python_for_build
-    # which is expected by the patch
-    cp ${STAGE_DIR}/native/bin/python_native ${S}/python_for_build
-}
-
 EXTRA_OEMAKE_COMPILE:native="python Parser/pgen"
 EXTRA_OECONF:machine = "\
   --disable-ipv6\
@@ -44,10 +35,8 @@ do_install[postfuncs] += "${DO_INSTALL_EXTRA_FILES}"
 DO_INSTALL_EXTRA_FILES = ""
 DO_INSTALL_EXTRA_FILES:native = "do_install_extra_files"
 do_install_extra_files () {
-	install -m 0755 ${S}/python \
-		${D}/bin/python_native
 	install -m 0755 ${S}/Parser/pgen \
-		${D}/bin/pgen_native
+		${D}/bin/pgen
 }
 
 

--- a/recipes/python/python.inc
+++ b/recipes/python/python.inc
@@ -7,12 +7,12 @@ RECIPE_TYPES = "native machine"
 
 inherit autotools  make
 
-CROSS_DEPENDS = "native:python readline-dev openssl libssl  libz readline readline-dev libreadline libreadline-dev libffi zlib  libcrypto  libtermcap libm"
+CROSS_DEPENDS = "native:python libssl libz libreadline libffi zlib libcrypto libtermcap libm"
 CROSS_DEPENDS:native = ""
 DEPENDS += "${CROSS_DEPENDS}"
 
-DEPENDS_${PN}:machine += " libz openssl libssl  readline readline-dev libreadline libreadline-dev  libffi zlib  libcrypto libtermcap libm "
-RDEPENDS_${PN}:machine += " libz openssl libssl  readline libreadline  libffi zlib  libcrypto libtermcap libm "
+DEPENDS_${PN}:machine += " libz libssl libreadline libffi zlib libcrypto libtermcap libm "
+RDEPENDS_${PN}:machine += "libz libssl libreadline libffi zlib libcrypto libtermcap libm "
 
 SRC_URI = "http://www.python.org/ftp/python/${PV}/Python-${PV}.tar.bz2"
 # The machine needs to be patched

--- a/recipes/python/python/Python-2.7.5-xcompile.patch
+++ b/recipes/python/python/Python-2.7.5-xcompile.patch
@@ -1,0 +1,211 @@
+diff --git a/packages/Python-2.7.5/Makefile.pre.in b/packages/Python-2.7.5/Makefile.pre.in
+index 9d55550..b028235 100644
+--- a/packages/Python-2.7.5/Makefile.pre.in
++++ b/packages/Python-2.7.5/Makefile.pre.in
+@@ -227,6 +227,7 @@ LIBFFI_INCLUDEDIR=	@LIBFFI_INCLUDEDIR@
+ ##########################################################################
+ # Parser
+ PGEN=		Parser/pgen$(EXE)
++PGEN_FOR_BUILD=Parser/pgen_for_build
+ 
+ PSRCS=		\
+ 		Parser/acceler.c \
+@@ -455,8 +456,9 @@ sharedmods: $(BUILDPYTHON) pybuilddir.txt
+ 	    *\ -s*|s*) quiet="-q";; \
+ 	    *) quiet="";; \
+ 	esac; \
+-	$(RUNSHARED) CC='$(CC)' LDSHARED='$(BLDSHARED)' OPT='$(OPT)' \
+-		$(PYTHON_FOR_BUILD) $(srcdir)/setup.py $$quiet build
++	$(RUNSHARED) CC='$(CC)' LDSHARED='$(BLDSHARED)' OPT='$(OPT)'    \
++		PYTHONXCPREFIX='$(DESTDIR)$(prefix)' $(PYTHON_FOR_BUILD)    \
++        $(srcdir)/setup.py $$quiet build
+ 
+ # Build static library
+ # avoid long command lines, same as LIBRARY_OBJS
+@@ -593,7 +595,7 @@ Modules/pwdmodule.o: $(srcdir)/Modules/pwdmodule.c $(srcdir)/Modules/posixmodule
+ $(GRAMMAR_H): $(GRAMMAR_INPUT) $(PGENSRCS)
+ 		@$(MKDIR_P) Include
+ 		$(MAKE) $(PGEN)
+-		$(PGEN) $(GRAMMAR_INPUT) $(GRAMMAR_H) $(GRAMMAR_C)
++		$(PGEN_FOR_BUILD) $(GRAMMAR_INPUT) $(GRAMMAR_H) $(GRAMMAR_C)
+ $(GRAMMAR_C): $(GRAMMAR_H) $(GRAMMAR_INPUT) $(PGENSRCS)
+ 		$(MAKE) $(GRAMMAR_H)
+ 		touch $(GRAMMAR_C)
+@@ -1000,12 +1002,12 @@ libinstall:	build_all $(srcdir)/Lib/$(PLATDIR) $(srcdir)/Modules/xxmodule.c
+ 		$(INSTALL_DATA) $(srcdir)/Modules/xxmodule.c \
+ 			$(DESTDIR)$(LIBDEST)/distutils/tests ; \
+ 	fi
+-	PYTHONPATH=$(DESTDIR)$(LIBDEST)  $(RUNSHARED) \
++	-PYTHONPATH=$(DESTDIR)$(LIBDEST)  $(RUNSHARED) \
+ 		$(PYTHON_FOR_BUILD) -Wi -tt $(DESTDIR)$(LIBDEST)/compileall.py \
+ 		-d $(LIBDEST) -f \
+ 		-x 'bad_coding|badsyntax|site-packages|lib2to3/tests/data' \
+ 		$(DESTDIR)$(LIBDEST)
+-	PYTHONPATH=$(DESTDIR)$(LIBDEST) $(RUNSHARED) \
++	-PYTHONPATH=$(DESTDIR)$(LIBDEST) $(RUNSHARED) \
+ 		$(PYTHON_FOR_BUILD) -Wi -tt -O $(DESTDIR)$(LIBDEST)/compileall.py \
+ 		-d $(LIBDEST) -f \
+ 		-x 'bad_coding|badsyntax|site-packages|lib2to3/tests/data' \
+@@ -1133,11 +1135,13 @@ libainstall:	all python-config
+ # Install the dynamically loadable modules
+ # This goes into $(exec_prefix)
+ sharedinstall: sharedmods
++	CC='$(CC)' LDSHARED='$(BLDSHARED)' OPT='$(OPT)' \
+ 	$(RUNSHARED) $(PYTHON_FOR_BUILD) $(srcdir)/setup.py install \
++		--skip-build \
+ 	   	--prefix=$(prefix) \
+-		--install-scripts=$(BINDIR) \
+-		--install-platlib=$(DESTSHARED) \
+-		--root=$(DESTDIR)/
++		--install-scripts=$(DESTDIR)$(BINDIR) \
++		--install-platlib=$(DESTDIR)$(DESTSHARED) \
++		--root=/
+ 	-rm $(DESTDIR)$(DESTSHARED)/_sysconfigdata.py*
+ 
+ # Here are a couple of targets for MacOSX again, to install a full
+diff --git a/packages/Python-2.7.5/Modules/Setup.dist b/packages/Python-2.7.5/Modules/Setup.dist
+index 2ad1aa3..ede793f 100644
+--- a/packages/Python-2.7.5/Modules/Setup.dist
++++ b/packages/Python-2.7.5/Modules/Setup.dist
+@@ -163,7 +163,7 @@ GLHACK=-Dclear=__GLclear
+ # it, depending on your system -- see the GNU readline instructions.
+ # It's okay for this to be a shared library, too.
+ 
+-#readline readline.c -lreadline -ltermcap
++readline readline.c -lreadline -ltermcap
+ 
+ 
+ # Modules that should always be present (non UNIX dependent):
+@@ -215,10 +215,10 @@ GLHACK=-Dclear=__GLclear
+ 
+ # Socket module helper for SSL support; you must comment out the other
+ # socket line above, and possibly edit the SSL variable:
+-#SSL=/usr/local/ssl
+-#_ssl _ssl.c \
+-#	-DUSE_SSL -I$(SSL)/include -I$(SSL)/include/openssl \
+-#	-L$(SSL)/lib -lssl -lcrypto
++SSL=/usr/local/ssl
++_ssl _ssl.c \
++	-DUSE_SSL -I$(SSL)/include -I$(SSL)/include/openssl \
++	-L$(SSL)/lib -lssl -lcrypto
+ 
+ # The crypt module is now disabled by default because it breaks builds
+ # on many systems (where -lcrypt is needed), e.g. Linux (I believe).
+@@ -464,7 +464,7 @@ GLHACK=-Dclear=__GLclear
+ # Andrew Kuchling's zlib module.
+ # This require zlib 1.1.3 (or later).
+ # See http://www.gzip.org/zlib/
+-#zlib zlibmodule.c -I$(prefix)/include -L$(exec_prefix)/lib -lz
++zlib zlibmodule.c -I$(prefix)/include -L$(exec_prefix)/lib -lz
+ 
+ # Interface to the Expat XML parser
+ #
+diff --git a/packages/Python-2.7.5/configure b/packages/Python-2.7.5/configure
+index dc0dfd0..083ef1b 100755
+--- a/packages/Python-2.7.5/configure
++++ b/packages/Python-2.7.5/configure
+@@ -2849,24 +2849,11 @@ case $host_os in *\ *) host_os=`echo "$host_os" | sed 's/ /-/g'`;; esac
+ 
+ 
+ 
++# Use latest cross-compiling patches
+ if test "$cross_compiling" = yes; then
+     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for python interpreter for cross build" >&5
+ $as_echo_n "checking for python interpreter for cross build... " >&6; }
+-    if test -z "$PYTHON_FOR_BUILD"; then
+-        for interp in python$PACKAGE_VERSION python2 python; do
+-	    which $interp >/dev/null 2>&1 || continue
+-	    if $interp -c 'import sys;sys.exit(not (sys.version_info[:2] >= (2,7) and sys.version_info[0] < 3))'; then
+-	        break
+-	    fi
+-            interp=
+-	done
+-        if test x$interp = x; then
+-	    as_fn_error $? "python$PACKAGE_VERSION interpreter not found" "$LINENO" 5
+-	fi
+-        { $as_echo "$as_me:${as_lineno-$LINENO}: result: $interp" >&5
+-$as_echo "$interp" >&6; }
+-	PYTHON_FOR_BUILD='_PYTHON_PROJECT_BASE=$(abs_builddir) _PYTHON_HOST_PLATFORM=$(_PYTHON_HOST_PLATFORM) PYTHONPATH=$(shell test -f pybuilddir.txt && echo $(abs_builddir)/`cat pybuilddir.txt`:)$(srcdir)/Lib:$(srcdir)/Lib/plat-$(MACHDEP) '$interp
+-    fi
++    PYTHON_FOR_BUILD='_PYTHON_PROJECT_BASE=$(abs_builddir) _PYTHON_HOST_PLATFORM=$(_PYTHON_HOST_PLATFORM) PYTHONPATH=$(shell test -f pybuilddir.txt && echo $(abs_builddir)/`cat pybuilddir.txt`:)$(srcdir)/Lib:$(srcdir)/Lib/plat-$(MACHDEP) $(srcdir)/$(BUILDPYTHON)_for_build'
+ elif test "$cross_compiling" = maybe; then
+     as_fn_error $? "Cross compiling required --host=HOST-TUPLE and --build=ARCH" "$LINENO" 5
+ else
+diff --git a/packages/Python-2.7.5/setup.py b/packages/Python-2.7.5/setup.py
+index 716f08e..ca8b141 100644
+--- a/packages/Python-2.7.5/setup.py
++++ b/packages/Python-2.7.5/setup.py
+@@ -17,7 +17,7 @@ from distutils.command.install import install
+ from distutils.command.install_lib import install_lib
+ from distutils.spawn import find_executable
+ 
+-cross_compiling = "_PYTHON_HOST_PLATFORM" in os.environ
++cross_compiling = ("_PYTHON_HOST_PLATFORM" in os.environ) or ('PYTHONXCPREFIX' in os.environ)
+ 
+ def get_platform():
+     # cross build
+@@ -324,6 +324,9 @@ class PyBuildExt(build_ext):
+ 
+         # Don't try to load extensions for cross builds
+         if cross_compiling:
++            self.announce(
++                 'WARNING: skipping import check for cross-compiled: "%s"' %
++                 ext.name)
+             return
+ 
+         try:
+@@ -436,11 +439,12 @@ class PyBuildExt(build_ext):
+             os.unlink(tmpfile)
+ 
+     def detect_modules(self):
+-        # Ensure that /usr/local is always used
+-        add_dir_to_list(self.compiler.library_dirs, '/usr/local/lib')
+-        add_dir_to_list(self.compiler.include_dirs, '/usr/local/include')
+-        self.add_gcc_paths()
+-        self.add_multiarch_paths()
++        # Ensure that /usr/local is always used, unless cross-compiling
++        if cross_compiling:
++            add_dir_to_list(self.compiler.library_dirs, '/usr/local/lib')
++            add_dir_to_list(self.compiler.include_dirs, '/usr/local/include')
++            self.add_gcc_paths()
++            self.add_multiarch_paths()
+ 
+         # Add paths specified in the environment variables LDFLAGS and
+         # CPPFLAGS for header and library files.
+@@ -476,7 +480,7 @@ class PyBuildExt(build_ext):
+                     for directory in reversed(options.dirs):
+                         add_dir_to_list(dir_list, directory)
+ 
+-        if os.path.normpath(sys.prefix) != '/usr' \
++        if os.path.normpath(sys.prefix) != '/usr' and not cross_compiling \
+                 and not sysconfig.get_config_var('PYTHONFRAMEWORK'):
+             # OSX note: Don't add LIBDIR and INCLUDEDIR to building a framework
+             # (PYTHONFRAMEWORK is set) to avoid # linking problems when
+@@ -552,6 +556,11 @@ class PyBuildExt(build_ext):
+         if host_platform in ['darwin', 'beos']:
+             math_libs = []
+ 
++        # Insert libraries and headers from embedded root file system (RFS)
++        if 'RFS' in os.environ:
++            lib_dirs += [os.environ['RFS'] + '/usr/lib']
++            inc_dirs += [os.environ['RFS'] + '/usr/include']
++
+         # XXX Omitted modules: gl, pure, dl, SGI-specific modules
+ 
+         #
+@@ -1975,8 +1984,13 @@ class PyBuildExt(build_ext):
+ 
+                 # Pass empty CFLAGS because we'll just append the resulting
+                 # CFLAGS to Python's; -g or -O2 is to be avoided.
+-                cmd = "cd %s && env CFLAGS='' '%s/configure' %s" \
+-                      % (ffi_builddir, ffi_srcdir, " ".join(config_args))
++                if cross_compiling:
++                    cmd = "cd %s && env CFLAGS='' '%s/configure' --host=%s --build=%s %s" \
++                          % (ffi_builddir, ffi_srcdir, os.environ.get('HOSTARCH'),
++                             os.environ.get('BUILDARCH'), " ".join(config_args))
++                else:
++                    cmd = "cd %s && env CFLAGS='' '%s/configure' %s" \
++                          % (ffi_builddir, ffi_srcdir, " ".join(config_args))
+ 
+                 res = os.system(cmd)
+                 if res or not os.path.exists(ffi_configfile):

--- a/recipes/python/python/Python-2.7.5-xcompile.patch
+++ b/recipes/python/python/Python-2.7.5-xcompile.patch
@@ -6,7 +6,7 @@ index 9d55550..b028235 100644
  ##########################################################################
  # Parser
  PGEN=		Parser/pgen$(EXE)
-+PGEN_FOR_BUILD=pgen_native
++PGEN_FOR_BUILD=pgen
  
  PSRCS=		\
  		Parser/acceler.c \
@@ -100,37 +100,6 @@ index 2ad1aa3..ede793f 100644
  
  # Interface to the Expat XML parser
  #
-diff --git a/packages/Python-2.7.5/configure b/packages/Python-2.7.5/configure
-index dc0dfd0..083ef1b 100755
---- a/packages/Python-2.7.5/configure
-+++ b/packages/Python-2.7.5/configure
-@@ -2849,24 +2849,11 @@ case $host_os in *\ *) host_os=`echo "$host_os" | sed 's/ /-/g'`;; esac
- 
- 
- 
-+# Use latest cross-compiling patches
- if test "$cross_compiling" = yes; then
-     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for python interpreter for cross build" >&5
- $as_echo_n "checking for python interpreter for cross build... " >&6; }
--    if test -z "$PYTHON_FOR_BUILD"; then
--        for interp in python$PACKAGE_VERSION python2 python; do
--	    which $interp >/dev/null 2>&1 || continue
--	    if $interp -c 'import sys;sys.exit(not (sys.version_info[:2] >= (2,7) and sys.version_info[0] < 3))'; then
--	        break
--	    fi
--            interp=
--	done
--        if test x$interp = x; then
--	    as_fn_error $? "python$PACKAGE_VERSION interpreter not found" "$LINENO" 5
--	fi
--        { $as_echo "$as_me:${as_lineno-$LINENO}: result: $interp" >&5
--$as_echo "$interp" >&6; }
--	PYTHON_FOR_BUILD='_PYTHON_PROJECT_BASE=$(abs_builddir) _PYTHON_HOST_PLATFORM=$(_PYTHON_HOST_PLATFORM) PYTHONPATH=$(shell test -f pybuilddir.txt && echo $(abs_builddir)/`cat pybuilddir.txt`:)$(srcdir)/Lib:$(srcdir)/Lib/plat-$(MACHDEP) '$interp
--    fi
-+    PYTHON_FOR_BUILD='_PYTHON_PROJECT_BASE=$(abs_builddir) _PYTHON_HOST_PLATFORM=$(_PYTHON_HOST_PLATFORM) PYTHONPATH=$(shell test -f pybuilddir.txt && echo $(abs_builddir)/`cat pybuilddir.txt`:)$(srcdir)/Lib:$(srcdir)/Lib/plat-$(MACHDEP) $(srcdir)/$(BUILDPYTHON)_for_build'
- elif test "$cross_compiling" = maybe; then
-     as_fn_error $? "Cross compiling required --host=HOST-TUPLE and --build=ARCH" "$LINENO" 5
- else
 diff --git a/packages/Python-2.7.5/setup.py b/packages/Python-2.7.5/setup.py
 index 716f08e..ca8b141 100644
 --- a/packages/Python-2.7.5/setup.py

--- a/recipes/python/python/Python-2.7.5-xcompile.patch
+++ b/recipes/python/python/Python-2.7.5-xcompile.patch
@@ -6,7 +6,7 @@ index 9d55550..b028235 100644
  ##########################################################################
  # Parser
  PGEN=		Parser/pgen$(EXE)
-+PGEN_FOR_BUILD=Parser/pgen_for_build
++PGEN_FOR_BUILD=pgen_native
  
  PSRCS=		\
  		Parser/acceler.c \
@@ -96,7 +96,7 @@ index 2ad1aa3..ede793f 100644
  # This require zlib 1.1.3 (or later).
  # See http://www.gzip.org/zlib/
 -#zlib zlibmodule.c -I$(prefix)/include -L$(exec_prefix)/lib -lz
-+zlib zlibmodule.c -I$(prefix)/include -L$(exec_prefix)/lib -lz
++zlib zlibmodule.c  -lz
  
  # Interface to the Expat XML parser
  #

--- a/recipes/python/python/Python-2.7.8-xcompile.patch
+++ b/recipes/python/python/Python-2.7.8-xcompile.patch
@@ -92,15 +92,6 @@ diff --git a/packages/Python-2.7.5/setup.py b/packages/Python-2.7.5/setup.py
 index 716f08e..ca8b141 100644
 --- a/packages/Python-2.7.5/setup.py
 +++ b/packages/Python-2.7.5/setup.py
-@@ -17,7 +17,7 @@ from distutils.command.install import install
- from distutils.command.install_lib import install_lib
- from distutils.spawn import find_executable
- 
--cross_compiling = "_PYTHON_HOST_PLATFORM" in os.environ
-+cross_compiling = ("_PYTHON_HOST_PLATFORM" in os.environ) or ('PYTHONXCPREFIX' in os.environ)
- 
- def get_platform():
-     # cross build
 @@ -324,6 +324,9 @@ class PyBuildExt(build_ext):
  
          # Don't try to load extensions for cross builds
@@ -120,18 +111,6 @@ index 716f08e..ca8b141 100644
                  and not sysconfig.get_config_var('PYTHONFRAMEWORK'):
              # OSX note: Don't add LIBDIR and INCLUDEDIR to building a framework
              # (PYTHONFRAMEWORK is set) to avoid # linking problems when
-@@ -552,6 +556,11 @@ class PyBuildExt(build_ext):
-         if host_platform in ['darwin', 'beos']:
-             math_libs = []
- 
-+        # Insert libraries and headers from embedded root file system (RFS)
-+        if 'RFS' in os.environ:
-+            lib_dirs += [os.environ['RFS'] + '/usr/lib']
-+            inc_dirs += [os.environ['RFS'] + '/usr/include']
-+
-         # XXX Omitted modules: gl, pure, dl, SGI-specific modules
- 
-         #
 @@ -1975,8 +1984,13 @@ class PyBuildExt(build_ext):
  
                  # Pass empty CFLAGS because we'll just append the resulting

--- a/recipes/python/python/Python-2.7.8-xcompile.patch
+++ b/recipes/python/python/Python-2.7.8-xcompile.patch
@@ -1,0 +1,150 @@
+diff --git a/packages/Python-2.7.5/Makefile.pre.in b/packages/Python-2.7.5/Makefile.pre.in
+index 9d55550..b028235 100644
+--- a/packages/Python-2.7.5/Makefile.pre.in
++++ b/packages/Python-2.7.5/Makefile.pre.in
+@@ -227,6 +227,7 @@ LIBFFI_INCLUDEDIR=	@LIBFFI_INCLUDEDIR@
+ ##########################################################################
+ # Parser
+ PGEN=		Parser/pgen$(EXE)
++PGEN_FOR_BUILD=pgen
+ 
+ PSRCS=		\
+ 		Parser/acceler.c \
+@@ -593,7 +595,7 @@ Modules/pwdmodule.o: $(srcdir)/Modules/pwdmodule.c $(srcdir)/Modules/posixmodule
+ $(GRAMMAR_H): $(GRAMMAR_INPUT) $(PGENSRCS)
+ 		@$(MKDIR_P) Include
+ 		$(MAKE) $(PGEN)
+-		$(PGEN) $(GRAMMAR_INPUT) $(GRAMMAR_H) $(GRAMMAR_C)
++		$(PGEN_FOR_BUILD) $(GRAMMAR_INPUT) $(GRAMMAR_H) $(GRAMMAR_C)
+ $(GRAMMAR_C): $(GRAMMAR_H) $(GRAMMAR_INPUT) $(PGENSRCS)
+ 		$(MAKE) $(GRAMMAR_H)
+ 		touch $(GRAMMAR_C)
+@@ -1000,12 +1002,12 @@ libinstall:	build_all $(srcdir)/Lib/$(PLATDIR) $(srcdir)/Modules/xxmodule.c
+ 		$(INSTALL_DATA) $(srcdir)/Modules/xxmodule.c \
+ 			$(DESTDIR)$(LIBDEST)/distutils/tests ; \
+ 	fi
+-	PYTHONPATH=$(DESTDIR)$(LIBDEST)  $(RUNSHARED) \
++	-PYTHONPATH=$(DESTDIR)$(LIBDEST)  $(RUNSHARED) \
+ 		$(PYTHON_FOR_BUILD) -Wi -tt $(DESTDIR)$(LIBDEST)/compileall.py \
+ 		-d $(LIBDEST) -f \
+ 		-x 'bad_coding|badsyntax|site-packages|lib2to3/tests/data' \
+ 		$(DESTDIR)$(LIBDEST)
+-	PYTHONPATH=$(DESTDIR)$(LIBDEST) $(RUNSHARED) \
++	-PYTHONPATH=$(DESTDIR)$(LIBDEST) $(RUNSHARED) \
+ 		$(PYTHON_FOR_BUILD) -Wi -tt -O $(DESTDIR)$(LIBDEST)/compileall.py \
+ 		-d $(LIBDEST) -f \
+ 		-x 'bad_coding|badsyntax|site-packages|lib2to3/tests/data' \
+@@ -1133,11 +1135,13 @@ libainstall:	all python-config
+ # Install the dynamically loadable modules
+ # This goes into $(exec_prefix)
+ sharedinstall: sharedmods
++	CC='$(CC)' LDSHARED='$(BLDSHARED)' OPT='$(OPT)' \
+ 	$(RUNSHARED) $(PYTHON_FOR_BUILD) $(srcdir)/setup.py install \
++		--skip-build \
+ 	   	--prefix=$(prefix) \
+-		--install-scripts=$(BINDIR) \
+-		--install-platlib=$(DESTSHARED) \
+-		--root=$(DESTDIR)/
++		--install-scripts=$(DESTDIR)$(BINDIR) \
++		--install-platlib=$(DESTDIR)$(DESTSHARED) \
++		--root=/
+ 	-rm $(DESTDIR)$(DESTSHARED)/_sysconfigdata.py*
+ 
+ # Here are a couple of targets for MacOSX again, to install a full
+diff --git a/packages/Python-2.7.5/Modules/Setup.dist b/packages/Python-2.7.5/Modules/Setup.dist
+index 2ad1aa3..ede793f 100644
+--- a/packages/Python-2.7.5/Modules/Setup.dist
++++ b/packages/Python-2.7.5/Modules/Setup.dist
+@@ -163,7 +163,7 @@ GLHACK=-Dclear=__GLclear
+ # it, depending on your system -- see the GNU readline instructions.
+ # It's okay for this to be a shared library, too.
+ 
+-#readline readline.c -lreadline -ltermcap
++readline readline.c -lreadline -ltermcap
+ 
+ 
+ # Modules that should always be present (non UNIX dependent):
+@@ -215,10 +215,10 @@ GLHACK=-Dclear=__GLclear
+ 
+ # Socket module helper for SSL support; you must comment out the other
+ # socket line above, and possibly edit the SSL variable:
+-#SSL=/usr/local/ssl
+-#_ssl _ssl.c \
+-#	-DUSE_SSL -I$(SSL)/include -I$(SSL)/include/openssl \
+-#	-L$(SSL)/lib -lssl -lcrypto
++SSL=/usr/local/ssl
++_ssl _ssl.c \
++	-DUSE_SSL -I$(SSL)/include -I$(SSL)/include/openssl \
++	-L$(SSL)/lib -lssl -lcrypto
+ 
+ # The crypt module is now disabled by default because it breaks builds
+ # on many systems (where -lcrypt is needed), e.g. Linux (I believe).
+@@ -464,7 +464,7 @@ GLHACK=-Dclear=__GLclear
+ # Andrew Kuchling's zlib module.
+ # This require zlib 1.1.3 (or later).
+ # See http://www.gzip.org/zlib/
+-#zlib zlibmodule.c -I$(prefix)/include -L$(exec_prefix)/lib -lz
++zlib zlibmodule.c  -lz
+ 
+ # Interface to the Expat XML parser
+ #
+diff --git a/packages/Python-2.7.5/setup.py b/packages/Python-2.7.5/setup.py
+index 716f08e..ca8b141 100644
+--- a/packages/Python-2.7.5/setup.py
++++ b/packages/Python-2.7.5/setup.py
+@@ -17,7 +17,7 @@ from distutils.command.install import install
+ from distutils.command.install_lib import install_lib
+ from distutils.spawn import find_executable
+ 
+-cross_compiling = "_PYTHON_HOST_PLATFORM" in os.environ
++cross_compiling = ("_PYTHON_HOST_PLATFORM" in os.environ) or ('PYTHONXCPREFIX' in os.environ)
+ 
+ def get_platform():
+     # cross build
+@@ -324,6 +324,9 @@ class PyBuildExt(build_ext):
+ 
+         # Don't try to load extensions for cross builds
+         if cross_compiling:
++            self.announce(
++                 'WARNING: skipping import check for cross-compiled: "%s"' %
++                 ext.name)
+             return
+ 
+         try:
+@@ -476,7 +480,7 @@ class PyBuildExt(build_ext):
+                     for directory in reversed(options.dirs):
+                         add_dir_to_list(dir_list, directory)
+ 
+-        if os.path.normpath(sys.prefix) != '/usr' \
++        if os.path.normpath(sys.prefix) != '/usr' and not cross_compiling \
+                 and not sysconfig.get_config_var('PYTHONFRAMEWORK'):
+             # OSX note: Don't add LIBDIR and INCLUDEDIR to building a framework
+             # (PYTHONFRAMEWORK is set) to avoid # linking problems when
+@@ -552,6 +556,11 @@ class PyBuildExt(build_ext):
+         if host_platform in ['darwin', 'beos']:
+             math_libs = []
+ 
++        # Insert libraries and headers from embedded root file system (RFS)
++        if 'RFS' in os.environ:
++            lib_dirs += [os.environ['RFS'] + '/usr/lib']
++            inc_dirs += [os.environ['RFS'] + '/usr/include']
++
+         # XXX Omitted modules: gl, pure, dl, SGI-specific modules
+ 
+         #
+@@ -1975,8 +1984,13 @@ class PyBuildExt(build_ext):
+ 
+                 # Pass empty CFLAGS because we'll just append the resulting
+                 # CFLAGS to Python's; -g or -O2 is to be avoided.
+-                cmd = "cd %s && env CFLAGS='' '%s/configure' %s" \
+-                      % (ffi_builddir, ffi_srcdir, " ".join(config_args))
++                if cross_compiling:
++                    cmd = "cd %s && env CFLAGS='' '%s/configure' --host=%s --build=%s %s" \
++                          % (ffi_builddir, ffi_srcdir, os.environ.get('HOSTARCH'),
++                             os.environ.get('BUILDARCH'), " ".join(config_args))
++                else:
++                    cmd = "cd %s && env CFLAGS='' '%s/configure' %s" \
++                          % (ffi_builddir, ffi_srcdir, " ".join(config_args))
+ 
+                 res = os.system(cmd)
+                 if res or not os.path.exists(ffi_configfile):

--- a/recipes/python/python_2.7.5.oe
+++ b/recipes/python/python_2.7.5.oe
@@ -1,0 +1,10 @@
+require python.inc
+
+#DEFAULT_PREFERENCE = "-1"
+
+# Parallel build bug seen in zlib-1.2.5, although seemingly very rare.
+# Produced on "Intel(R) Core(TM) i7 CPU Q 740 @ 1.73GHz" with -j16
+# gcc -shared -Wl,-soname,libz.so.1,--version-script,zlib.map -isystem /data/home/oe-lite/mikrofyn/tmp/work/native/x86_64-unknown-linux-gnu/zlib-native-1.2.5-r0/stage/native/include -O3 -U_FORTIFY_SOURCE -fPIC -D_LARGEFILE64_SOURCE=1 -o libz.so.1.2.5 adler32.lo compress.lo crc32.lo deflate.lo gzclose.lo gzlib.lo gzread.lo gzwrite.lo infback.lo inffast.lo inflate.lo inftrees.lo trees.lo uncompr.lo zutil.lo  -lc -Wl,-O1 -Wl,-z -Wl,origin -Wl,--hash-style=gnu -Wl,-rpath,/data/home/oe-lite/mikrofyn/tmp/work/native/x86_64-unknown-linux-gnu/zlib-native-1.2.5-r0/stage/native/lib -L/data/home/oe-lite/mikrofyn/tmp/work/native/x86_64-unknown-linux-gnu/zlib-native-1.2.5-r0/stage/native/lib -L. libz.a
+# gcc: libz.a: No such file or directory
+# make: *** [libz.so.1.2.5] Error 1
+#PARALLEL_MAKE = ""

--- a/recipes/python/python_2.7.5.oe
+++ b/recipes/python/python_2.7.5.oe
@@ -1,10 +1,1 @@
 require python.inc
-
-#DEFAULT_PREFERENCE = "-1"
-
-# Parallel build bug seen in zlib-1.2.5, although seemingly very rare.
-# Produced on "Intel(R) Core(TM) i7 CPU Q 740 @ 1.73GHz" with -j16
-# gcc -shared -Wl,-soname,libz.so.1,--version-script,zlib.map -isystem /data/home/oe-lite/mikrofyn/tmp/work/native/x86_64-unknown-linux-gnu/zlib-native-1.2.5-r0/stage/native/include -O3 -U_FORTIFY_SOURCE -fPIC -D_LARGEFILE64_SOURCE=1 -o libz.so.1.2.5 adler32.lo compress.lo crc32.lo deflate.lo gzclose.lo gzlib.lo gzread.lo gzwrite.lo infback.lo inffast.lo inflate.lo inftrees.lo trees.lo uncompr.lo zutil.lo  -lc -Wl,-O1 -Wl,-z -Wl,origin -Wl,--hash-style=gnu -Wl,-rpath,/data/home/oe-lite/mikrofyn/tmp/work/native/x86_64-unknown-linux-gnu/zlib-native-1.2.5-r0/stage/native/lib -L/data/home/oe-lite/mikrofyn/tmp/work/native/x86_64-unknown-linux-gnu/zlib-native-1.2.5-r0/stage/native/lib -L. libz.a
-# gcc: libz.a: No such file or directory
-# make: *** [libz.so.1.2.5] Error 1
-#PARALLEL_MAKE = ""

--- a/recipes/python/python_2.7.5.oe.sig
+++ b/recipes/python/python_2.7.5.oe.sig
@@ -1,0 +1,1 @@
+6cfada1a739544a6fa7f2601b500fba02229656b  Python-2.7.5.tar.bz2

--- a/recipes/python/python_2.7.8.oe
+++ b/recipes/python/python_2.7.8.oe
@@ -1,0 +1,1 @@
+require python.inc

--- a/recipes/python/python_2.7.8.oe.sig
+++ b/recipes/python/python_2.7.8.oe.sig
@@ -1,0 +1,1 @@
+9c6281eeace0c3646fa556c8087bb1b7e033c9c4  Python-2.7.8.tar.xz


### PR DESCRIPTION
Adding a new recipe to enabled python on the target. 
The recipe is based on the description from this page: 
http://www.trevorbowen.com/2013/10/07/cross-compiling-python-2-7-5-for-embedded-linux/ 
 And I have used the patch he refers as the basis, but it has been modified slightly. 

I have tested the build on a RaspberryPI running: 
python /usr/lib/python-2.7/test/test___all__.py