### PR TITLE
Gettext: compile without termlibs prefix

### DIFF
--- a/recipes/gettext/gettext.inc
+++ b/recipes/gettext/gettext.inc
@@ -46,6 +46,7 @@ EXTRA_OECONF += "\
 --with-included-libunistring \
 --with-included-libcroco \
 --without-emacs --without-git --without-cvs \
+--without-libcurses-prefix --without-libncurses-prefix --without-libtermcap-prexix --without-libxcurses-prefix \
 --with-included-glib \
 "
 


### PR DESCRIPTION
Without that option it appends libdir(/usr/lib) in LD_FLAGS so it is conflicting with build machine libraries