### PR TITLE
Remove explicit handling of PIDFILE for watchdog app

### DIFF
--- a/recipes/busybox/files/busybox-watchdog
+++ b/recipes/busybox/files/busybox-watchdog
@@ -1,18 +1,22 @@
 #!/bin/sh
 
+# The busybox watchdog applet creates and removes
+# /var/run/watchdog.pid.
+#
+# It is removed explicitly in stop to be certain
+# it is gone.
+
 PIDFILE=/var/run/watchdog.pid
 WATCHDOG=/dev/watchdog
 
 case "$1" in
     start)
 	splash_progress PLACEHOLDER
-	[ -f $PIDFILE ] \
-	    && kill `cat $PIDFILE`
+	[ -f $PIDFILE ] && kill `cat $PIDFILE`
 	watchdog -t 1 -F $WATCHDOG &
-	echo $! > $PIDFILE
         ;;
     stop)
 	kill `cat $PIDFILE`
-	rm $PIDFILE
+	rm -f $PIDFILE
 	;;
 esac


### PR DESCRIPTION
In my experience, the busybox watchdog app creates and deletes
the /var/run/watchdog.pid file, and the explicit creation/deletion
of the pidfile in the busybox-watchdog script leads to warning
messages when stopping busybox-watchdog.