### PR TITLE
openssh: Make ssh key generation more flexible and extend with ed25519

### DIFF
--- a/recipes/openssh/files/init
+++ b/recipes/openssh/files/init
@@ -1,6 +1,8 @@
 #! /bin/sh
 set -e
 
+HOST_KEY_TYPES=""
+
 # /etc/init.d/ssh: start and stop the OpenBSD "secure shell" daemon
 
 test -x /usr/sbin/sshd || exit 0
@@ -32,18 +34,14 @@ check_config() {
 
 check_keys() {
 	# create keys if necessary
-	if [ ! -f /etc/ssh/ssh_host_rsa_key ]; then
-		echo "  generating ssh RSA key..."
-		ssh-keygen -q -f /etc/ssh/ssh_host_rsa_key -N '' -t rsa
-	fi
-	if [ ! -f /etc/ssh/ssh_host_dsa_key ]; then
-		echo "  generating ssh DSA key..."
-		ssh-keygen -q -f /etc/ssh/ssh_host_dsa_key -N '' -t dsa
-	fi
-	if [ ! -f /etc/ssh/ssh_host_ecdsa_key ]; then
-		echo "  generating ssh ECDSA key..."
-		ssh-keygen -q -f /etc/ssh/ssh_host_ecdsa_key -N '' -t ecdsa
-	fi
+	for keytype in $HOST_KEY_TYPES ; do
+		keyfile="/etc/ssh/ssh_host_"$keytype"_key"
+		if [ ! -f "$keyfile" ]; then
+			echo "  generating ssh $keytype key..."
+			ssh-keygen -q -f "$keyfile" -N '' -t rsa
+			sync
+		fi
+	done
 }
 
 export PATH="${PATH:+$PATH:}/usr/sbin:/sbin"

--- a/recipes/openssh/openssh.inc
+++ b/recipes/openssh/openssh.inc
@@ -54,6 +54,14 @@ do_configure_sftp_server () {
     echo SFTP_LIBS=`grep ^LIBS= ${S}/Makefile | cut -b6- | sed 's/-lcrypto//'` >> ${S}/Makefile
 }
 
+HOST_KEY_TYPES ?= "rsa dsa ecdsa ed25519"
+
+do_configure[postfuncs] += "do_configure_host_key_generation"
+do_configure_host_key_generation() {
+    sed -e 's/\(HOST_KEY_TYPES\)=.*/\1="${HOST_KEY_TYPES}"/' \
+        -i ${SRCDIR}/init
+}
+
 do_compile[postfuncs] += "do_compile_install_config_files"
 do_compile_install_config_files () {
 	install -m 0644 ${SRCDIR}/sshd_config ${S}/


### PR DESCRIPTION
Avoid copy-paste of that 4 line conditional block, and update with current
list of 4 host key types.

Signed-off-by: Esben Haabendal <esben@haabendal.dk>