### PR TITLE
rsyslog: Fix rebuild bug by using make vpath

### DIFF
--- a/recipes/rsyslog/rsyslog.inc
+++ b/recipes/rsyslog/rsyslog.inc
@@ -14,7 +14,7 @@ SRC_URI = "http://www.rsyslog.com/files/download/rsyslog/${PN}-${PV}.tar.gz \
           file://rsyslog.conf \
           file://rsyslog"
 
-inherit autotools-autoreconf sysvinit pkgconfig
+inherit autotools-autoreconf make-vpath sysvinit pkgconfig
 
 RECIPE_FLAGS = "rsyslog_sysvinit_start rsyslog_logdir rsyslog_logfile"
 DEFAULT_USE_rsyslog_sysvinit_start = "20"


### PR DESCRIPTION
This has been verified to solve the problem just seen with rebuild failure
after do_stage being rerun.

Signed-off-by: Esben Haabendal <esben@haabendal.dk>