### PR TITLE
Upstream license fixes

### DIFF
--- a/recipes/apr/apr-util_1.5.4.oe
+++ b/recipes/apr/apr-util_1.5.4.oe
@@ -1,6 +1,6 @@
 require ${PN}.inc
 
-LICENSE = "Apache-2.0"
+LICENSE = "Apache-2.0,MIT-style,RSA-license,OpenLDAP-license"
 
 SRC_URI += "file://configfix.patch"
 SRC_URI += "file://configure_fixes.patch"

--- a/recipes/attr/attr.inc
+++ b/recipes/attr/attr.inc
@@ -1,6 +1,6 @@
 # -*- mode:python; -*-
 DESCRIPTION = "Commands for Manipulating Filesystem Extended Attributes"
-LICENSE = "GPLv2+"
+LICENSE = "GPL-2.0+,LGPL-2.1"
 
 RECIPE_TYPES = "machine native"
 COMPATIBLE_HOST_ARCHS = ".*linux"

--- a/recipes/base-files/base-hostname.oe
+++ b/recipes/base-files/base-hostname.oe
@@ -1,5 +1,5 @@
 DESCRIPTION = "Hostname script for the base system."
-LICENSE = "GPL-2.0"
+LICENSE = "MIT"
 
 COMPATIBLE_HOST_ARCHS = ".*linux"
 

--- a/recipes/base-passwd/base-passwd.oe
+++ b/recipes/base-passwd/base-passwd.oe
@@ -1,5 +1,5 @@
 DESCRIPTION = "OE-lite Linux minimal base passwd/group files"
-LICENSE = "GPL"
+LICENSE = "MIT"
 
 SRC_URI = "file://passwd file://group"
 S = "${SRCDIR}"

--- a/recipes/busybox/busybox.inc
+++ b/recipes/busybox/busybox.inc
@@ -1,7 +1,7 @@
 # -*- mode:python; -*-
 DESCRIPTION = "BusyBox: The Swiss Army Knife of Embedded Linux"
 HOMEPAGE = "http://www.busybox.net"
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0+"
 
 COMPATIBLE_HOST_ARCHS = ".*linux"
 

--- a/recipes/can-utils/can-utils.oe
+++ b/recipes/can-utils/can-utils.oe
@@ -1,5 +1,5 @@
 DESCRIPTION = "can-utils"
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0, BSD-3-Clause"
 
 COMPATIBLE_HOST_ARCHS = ".*linux"
 

--- a/recipes/dbus/dbus.inc
+++ b/recipes/dbus/dbus.inc
@@ -1,7 +1,7 @@
 # -*- mode:python; -*-
 DESCRIPTION = "A message bus system for inter-process communication"
 HOMEPAGE = "http://dbus.freedesktop.org"
-LICENSE = "GPLv2+ AFLv2.1"
+LICENSE = "GPL-2.0+,AFL-2.1"
 
 RECIPE_TYPES = "machine native sdk"
 COMPATIBLE_HOST_ARCHS = ".*linux .*darwin"

--- a/recipes/dosfstools/dosfstools.inc
+++ b/recipes/dosfstools/dosfstools.inc
@@ -4,7 +4,7 @@
 # Released under the MIT license (see packages/COPYING)
 
 DESCRIPTION = "DOS FAT Filesystem Utilities"
-LICENSE = "GPLv3"
+LICENSE = "GPL-3.0+"
 
 RECIPE_TYPES = "machine native sdk"
 COMPATIBLE_HOST_ARCHS = ".*linux .*darwin"

--- a/recipes/e2fsprogs/e2fsprogs_1.42.12.oe
+++ b/recipes/e2fsprogs/e2fsprogs_1.42.12.oe
@@ -1,4 +1,4 @@
-LICENSE = "GPL-2.0 & LGPL-2.0 & MIT & BSD-3-Clause*"
+LICENSE = "GPL-2.0+, LGPL-2.1+, MIT-style, BSD-style"
 
 require e2fsprogs.inc
 

--- a/recipes/ethtool/ethtool.inc
+++ b/recipes/ethtool/ethtool.inc
@@ -1,7 +1,7 @@
 DESCRIPTION = "A small utility for examining and tuning the settings \
 of your ethernet-based network interfaces."
 HOMEPAGE = "http://www.kernel.org/pub/software/network/ethtool/"
-LICENSE = "GPL"
+LICENSE = "GPL-2.0"
 
 COMPATIBLE_HOST_ARCHS = ".*linux"
 

--- a/recipes/fontconfig/fontconfig_2.11.1.oe
+++ b/recipes/fontconfig/fontconfig_2.11.1.oe
@@ -1,5 +1,5 @@
 require ${PN}.inc
-LICENSE = "BSD"
+LICENSE = "MIT-style"
 
 EXTRA_OECONF += "--without-xmldir"
 

--- a/recipes/freetype/freetype.inc
+++ b/recipes/freetype/freetype.inc
@@ -1,6 +1,6 @@
 # -*- mode:python; -*-
 DESCRIPTION = "Freetype font rendering library"
-LICENSE = "freetype GPLv2"
+LICENSE = "freetype | GPLv-2.0+"
 
 RECIPE_TYPES = "machine native"
 

--- a/recipes/gnupg/gnupg.inc
+++ b/recipes/gnupg/gnupg.inc
@@ -1,6 +1,6 @@
 DESCRIPTION = "gnupg - GNU privacy guard"
 HOMEPAGE = "http://www.gnupg.org/"
-LICENSE = "GPLv2"
+LICENSE = "GPL-3.0+, LGPL-3.0+"
 
 COMPATIBLE_HOST_ARCHS = ".*linux"
 

--- a/recipes/gnutls/libtasn1_4.2.oe
+++ b/recipes/gnutls/libtasn1_4.2.oe
@@ -1,8 +1,8 @@
 require ${PN}.inc
 
-LICENSE = "GPLv3+ & LGPLv2.1+"
-LICENSE_${PN}-bin = "GPLv3+"
-LICENSE_${PN} = "LGPLv2.1+"
+LICENSE = "GPL-3.0+ & LGPL-2.1+"
+LICENSE_${PN}-bin = "GPL-3.0+"
+LICENSE_${PN} = "LGPL-2.1+"
 
 SRC_URI += "file://libtasn1_fix_for_automake_1.12.patch"
 

--- a/recipes/hdparm/hdparm.inc
+++ b/recipes/hdparm/hdparm.inc
@@ -1,7 +1,7 @@
 DESCRIPTION = "hdparm is a Linux shell utility for viewing \
 and manipulating various IDE drive and driver parameters."
 SECTION = "console/utils"
-LICENSE = "BSD"
+LICENSE = "BSD-style"
 LICENSE_${PN}-wiper = "GPL-2.0"
 
 COMPATIBLE_HOST_ARCHS = ".*linux"

--- a/recipes/iproute2/iproute2.inc
+++ b/recipes/iproute2/iproute2.inc
@@ -3,7 +3,7 @@ DESCRIPTION = "Iproute2 is a collection of utilities for controlling \
 TCP / IP networking and traffic control in Linux.  Of the utilities ip \
 and tc are the most important.  ip controls IPv4 and IPv6 \
 configuration and tc stands for traffic control."
-LICENSE = "GPLv2+"
+LICENSE = "GPL-2.0+"
 
 COMPATIBLE_HOST_ARCHS = ".*linux"
 

--- a/recipes/libcap/libcap2.inc
+++ b/recipes/libcap/libcap2.inc
@@ -1,7 +1,7 @@
 # -*- mode:python; -*-
 DESCRIPTION = "Libcap is a library for getting and setting POSIX.1e \
 	(formerly POSIX 6) draft 15 capabilities."
-LICENSE = "GPL,BSD"
+LICENSE = "GPL-2.0+,BSD-3-Clause"
 
 RECIPE_TYPES = "machine"
 COMPATIBLE_HOST_ARCHS = ".*linux"

--- a/recipes/libestr/libestr_0.1.10.oe
+++ b/recipes/libestr/libestr_0.1.10.oe
@@ -1,7 +1,7 @@
 DESCRIPTION = "libestr - some essentials for string handling (and a bit more)"
 HOMEPAGE = "http://doc.libestr.adiscon.com/index.html"
 SRC_URI = "http://libestr.adiscon.com/files/download/${PN}-${PV}.tar.gz"
-LICENSE = "GPL-2.1"
+LICENSE = "LGPL-2.1"
 
 inherit autotools-autoreconf library
 

--- a/recipes/libgcrypt/libgcrypt.inc
+++ b/recipes/libgcrypt/libgcrypt.inc
@@ -1,5 +1,9 @@
 DESCRIPTION = "A general purpose cryptographic library based on the code from GnuPG"
 HOMEPAGE = "http://directory.fsf.org/project/libgcrypt/"
+BUGTRACKER = "https://bugs.g10code.com/gnupg/index"
+
+# helper program gcryptrnd and getrandom are under GPL, rest LGPL
+LICENSE = "GPL-2.0+ & LGPL-2.1+"
 
 COMPATIBLE_HOST_ARCHS = ".*linux"
 

--- a/recipes/libiconv/libiconv_1.14.oe
+++ b/recipes/libiconv/libiconv_1.14.oe
@@ -1,6 +1,6 @@
 require libiconv.inc
 
-LICENSE = "GPL-3.0 & LGPL-2.0"
+LICENSE = "GPL-3.0+, LGPL-2.0+"
 
 SRC_URI += "file://gets-undefined-in-C11.patch"
 

--- a/recipes/libnl/libnl_3.2.24.oe
+++ b/recipes/libnl/libnl_3.2.24.oe
@@ -1,6 +1,6 @@
 require ${PN}.inc
 
-LICENSE = "LGPLv2.1"
+LICENSE = "LGPLv2.1+"
 
 SRC_URI += "file://fix-pc-file.patch"
 

--- a/recipes/libpcap/libpcap.inc
+++ b/recipes/libpcap/libpcap.inc
@@ -1,7 +1,7 @@
 # -*- mode:python; -*-
 DESCRIPTION = "Network Packet Capture Library"
 HOMEPAGE = "http://www.tcpdump.org/"
-LICENSE = "BSD"
+LICENSE = "Modified BSD-3-Clause"
 
 RECIPE_TYPES = "machine"
 COMPATIBLE_HOST_ARCHS = ".*linux"

--- a/recipes/libusb/libusb-compat_0.1.5.oe
+++ b/recipes/libusb/libusb-compat_0.1.5.oe
@@ -1,6 +1,6 @@
 DESCRIPTION = "libusb-0 compatibility library using libusb-1"
 HOMEPAGE = "http://libusb.sf.net"
-LICENSE = "LGPLv2.1"
+LICENSE = "LGPL-2.1+"
 
 COMPATIBLE_HOST_ARCHS = ".*linux"
 

--- a/recipes/libusb/libusb1.inc
+++ b/recipes/libusb/libusb1.inc
@@ -1,6 +1,6 @@
 DESCRIPTION = "library to provide userspace access to USB devices"
 HOMEPAGE = "http://libusb.sf.net"
-LICENSE = "LGPLv2.1"
+LICENSE = "LGPL-2.1+"
 
 COMPATIBLE_HOST_ARCHS = ".*linux"
 

--- a/recipes/libxml/libxml2_2.9.2.oe
+++ b/recipes/libxml/libxml2_2.9.2.oe
@@ -1,4 +1,4 @@
-LICENSE = "MIT"
+LICENSE = "MIT-style"
 
 require libxml2.inc
 

--- a/recipes/lmsensors/lmsensors.inc
+++ b/recipes/lmsensors/lmsensors.inc
@@ -5,6 +5,9 @@ COMPATIBLE_MACHINES = ".*"
 
 inherit make c auto-package-libs
 
+LICENSE = "GPL-2.0+"
+LICENSE_${PN}-libsensors = "LGPL-2.1+"
+
 DEPENDS = "kernel-dev native:flex native:bison libm"
 
 DEPENDS_${PN} += "libc libm"

--- a/recipes/lmsensors/lmsensors_3.3.5.oe
+++ b/recipes/lmsensors/lmsensors_3.3.5.oe
@@ -1,7 +1,5 @@
 require lmsensors.inc
 
-LICENCE = "LGPL"
-
 SRC_URI += "file://makefile_machine_fix.patch"
 
 export HOST_CPU

--- a/recipes/net-tools/net-tools_1.60.oe
+++ b/recipes/net-tools/net-tools_1.60.oe
@@ -1,5 +1,5 @@
 SUMMARY="Basic networking tools"
-LICENSE="GPL"
+LICENSE="GPL-2.0+"
 
 COMPATIBLE_HOST_ARCHS = ".*linux"
 

--- a/recipes/nettle/nettle.inc
+++ b/recipes/nettle/nettle.inc
@@ -1,6 +1,8 @@
 DESCRIPTION = "The Nettle package contains the low-level cryptographic \
 	library that is designed to fit easily in many contexts"
-LICENSE = "LGPL-2.1+"
+LICENSE = "GPL-2.0+"
+LICENSE_${PN}-libnettle = "LGPL-2.1+"
+LICENSE_${PN}-libhogweed = "LGPL-2.1+"
 
 COMPATIBLE_HOST_ARCHS = ".*linux .*darwin"
 

--- a/recipes/openrdate/openrdate.inc
+++ b/recipes/openrdate/openrdate.inc
@@ -3,7 +3,7 @@ HOMEPAGE = "http://sourceforge.net/projects/openrdate/"
 
 COMPATIBLE_HOST_ARCHS = ".*linux"
 
-LICENSE = "BSD"
+LICENSE = "BSD-style"
 
 require conf/fetch/sourceforge.conf
 

--- a/recipes/openssh/openssh.inc
+++ b/recipes/openssh/openssh.inc
@@ -8,7 +8,7 @@ DESCRIPTION = "Secure rlogin/rsh/rcp/telnet replacement (OpenSSH) Ssh \
 	and rcp, and can be used to provide applications with a secure \
 	communication channel."
 HOMEPAGE = "http://www.openssh.org/"
-LICENSE = "BSD"
+LICENSE = "BSD-style"
 
 RECIPE_TYPES = "machine"
 COMPATIBLE_HOST_ARCHS = ".*linux"

--- a/recipes/rsync/rsync_3.1.1.oe
+++ b/recipes/rsync/rsync_3.1.1.oe
@@ -1,5 +1,5 @@
 DESCRIPTION = "rsync is an open source utility that provides fast incremental file transfer. "
-LICENSE = "GPL"
+LICENSE = "GPL-3.0+"
 
 SRC_URI = "http://rsync.samba.org/ftp/rsync/src/${PN}-${PV}.tar.gz"
 

--- a/recipes/rsyslog/rsyslog.inc
+++ b/recipes/rsyslog/rsyslog.inc
@@ -1,6 +1,6 @@
 DESCRIPTION = "Rsyslog is an enhanced multi-threaded syslogd"
 HOMEPAGE = "http://www.rsyslog.com/"
-LICENSE = "GPL-3.0"
+LICENSE = "GPL-3.0+,Apache-2.0-style,LGPL-3.0+"
 
 COMPATIBLE_HOST_ARCHS = ".*linux"
 

--- a/recipes/smartmontools/smartmontools.inc
+++ b/recipes/smartmontools/smartmontools.inc
@@ -1,5 +1,5 @@
 DESCRIPTION = "Control and monitor storage systems using S.M.A.R.T."
-LICENSE = "GPL"
+LICENSE = "GPL-2.0+"
 
 inherit c c++ autotools
 

--- a/recipes/sqlite/sqlite3_3.8.7.4.oe
+++ b/recipes/sqlite/sqlite3_3.8.7.4.oe
@@ -1,4 +1,4 @@
-LICENSE = "custom"
+LICENSE = "Public Domain"
 
 require sqlite3.inc
 

--- a/recipes/tcpdump/tcpdump.inc
+++ b/recipes/tcpdump/tcpdump.inc
@@ -1,7 +1,7 @@
 # -*- mode:python; -*-
 DESCRIPTION = "A sophisticated network protocol analyzer"
 HOMEPAGE = "http://www.tcpdump.org/"
-LICENSE = "BSD-4-Clause*"
+LICENSE = "BSD-3-Clause*"
 
 RECIPE_TYPES = "machine"
 COMPATIBLE_HOST_ARCHS = ".*linux"

--- a/recipes/u-boot/u-boot-tools_2011.09.oe
+++ b/recipes/u-boot/u-boot-tools_2011.09.oe
@@ -1,4 +1,5 @@
-LICENSE = "GPL-2.0 & GPL-2.0+"
+LICENSE = "GPL-2.0+"
+LICENSE_${PN}-env = "GPL-2.0+"
 
 require ${PN}.inc
 

--- a/recipes/usbutils/usbutils_007.oe
+++ b/recipes/usbutils/usbutils_007.oe
@@ -1,6 +1,6 @@
 # -*- mode:python; -*-
 DESCRIPTION = "Host side USB console utilities."
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0+"
 
 COMPATIBLE_HOST_ARCHS = ".*linux"
 

--- a/recipes/util-linux/util-linux_2.25.2.oe
+++ b/recipes/util-linux/util-linux_2.25.2.oe
@@ -1,5 +1,5 @@
 # -*- mode:python; -*-
-LICENSE = "GPL-3.0+ & GPL-2.0+ & GPL-2.0 & LGPL-2.0+ & BSD-4-Clause-UC*"
+LICENSE = "GPL-3.0+ & GPL-2.0+ & LGPL-2.1+ & BSD-4-Clause-style"
 
 inherit pkgconfig
 

--- a/recipes/wireless-tools/wireless-tools_29.oe
+++ b/recipes/wireless-tools/wireless-tools_29.oe
@@ -1,6 +1,6 @@
 require ${PN}.inc
 
-LICENSE = "GPLv2 & (LGPLv2.1 | MPL-1.1 | BSD)"
+LICENSE = "GPL-2.0+, LGPL-2.1+,MPL-1.1,BSD-style"
 
 SRC_URI += "file://remove.ldconfig.call.patch"
 SRC_URI += "file://man.patch"

--- a/recipes/wpa-supplicant/wpa-supplicant_2.3.oe
+++ b/recipes/wpa-supplicant/wpa-supplicant_2.3.oe
@@ -1,3 +1,3 @@
 require wpa-supplicant.inc
 
-LICENSE = "GPL-2.0 | BSD-3-Clause"
+LICENSE = "GPL-2.0+,  BSD-3-Clause"


### PR DESCRIPTION
use correct license specifiers. If the license is not strictly as listed by spdx.org, do not pretend that it is, but instead consistently say "foo-style" to indicate that it is inspired by the foo license