### PR TITLE
libtiff: disable build for mingw

### DIFF
--- a/recipes/libtiff/tiff.inc
+++ b/recipes/libtiff/tiff.inc
@@ -4,6 +4,8 @@ HOMEPAGE = "http://www.remotesensing.org/libtiff/"
 
 RECIPE_TYPES = "machine native"
 
+COMPATIBLE_HOST_ARCHS = ".*linux"
+
 SRC_URI = "ftp://ftp.remotesensing.org/pub/libtiff/tiff-${PV}.tar.gz"
 
 inherit autotools c++


### PR DESCRIPTION
currently there is a rebuild issue for mingw, issue tracked in
oe-lite/base issue #220