### PR TITLE
makedevs: apply mode setting on directories

### DIFF
--- a/recipes/makedevs/makedevs-1.0.0/makedevs.c
+++ b/recipes/makedevs/makedevs-1.0.0/makedevs.c
@@ -108,6 +108,7 @@ static void add_new_directory(char *name, char *path,
 {
 	mkdir(path, mode);
 	chown(path, uid, gid);
+	chmod(path, mode);
 //	printf("Directory: %s %s  UID: %ld  GID %ld  MODE: %ld\n", path, name, uid, gid, mode);
 }
 


### PR DESCRIPTION
The mode setting for directories in device table files were ignored in
add_new_directory(). Fix this by adding a call in chmod() in said
function.