### PR TITLE
rsyslog: The "-c5" option is not compatible with rsyslog 8.6.0

### DIFF
--- a/recipes/rsyslog/rsyslog/rsyslog
+++ b/recipes/rsyslog/rsyslog/rsyslog
@@ -5,7 +5,7 @@ PATH=/sbin:/usr/sbin:/bin:/usr/bin
 NAME=rsyslog
 RSYSLOGD=rsyslogd
 RSYSLOGD_BIN=/usr/sbin/rsyslogd
-RSYSLOGD_OPTIONS="-c5"
+RSYSLOGD_OPTIONS=""
 RSYSLOGD_PIDFILE=/var/run/rsyslogd.pid
 SCRIPTNAME=/etc/init.d/$NAME
 # Exit if the package is not installed


### PR DESCRIPTION
bugfix