### PR TITLE
busybox: Fix print out of bogus error messages when getting DHCP lease

### DIFF
--- a/recipes/busybox/busybox.inc
+++ b/recipes/busybox/busybox.inc
@@ -41,6 +41,7 @@ SRC_URI += "\
 	file://busybox-ifplugd.conf \
 "
 
+SRC_URI:>USE_busybox_udhcpc = " file://udhcp-simple-script-route-del-dev-null.patch"
 PACKAGES:<USE_busybox_udhcpc = "${PN}-udhcpc-scripts "
 
 RECIPE_FLAGS += "busybox_init_shutdown_umount"

--- a/recipes/busybox/files/udhcp-simple-script-route-del-dev-null.patch
+++ b/recipes/busybox/files/udhcp-simple-script-route-del-dev-null.patch
@@ -1,0 +1,13 @@
+Upstream-status: Pending
+
+--- busybox-1.16.1/examples/udhcp/simple.script.orig	2010-06-28 12:49:36.000000000 +0200
++++ busybox-1.16.1/examples/udhcp/simple.script	2010-06-28 12:49:55.000000000 +0200
+@@ -22,7 +22,7 @@
+ 
+ 		if [ -n "$router" ] ; then
+ 			echo "Deleting routers"
+-			while route del default gw 0.0.0.0 dev $interface ; do
++			while route del default gw 0.0.0.0 dev $interface 2>/dev/null; do
+ 				:
+ 			done
+ 


### PR DESCRIPTION
This re-adds a patch that was dropped when upgrading busybox.
It is still relevant, but probably needs a bit of extra attention to
be acceptable to upstream.

Signed-off-by: Esben Haabendal <esben@haabendal.dk>