### PR TITLE
busybox: Fix busybox_mdev USE flag handling

### DIFF
--- a/recipes/busybox/busybox-install.inc
+++ b/recipes/busybox/busybox-install.inc
@@ -34,6 +34,7 @@ do_install () {
 	fi
 
 	if grep "CONFIG_MDEV=y" ${S}/.config; then
+		install -d ${D}${sysconfdir}
 		install -m 0644 ${SRCDIR}/mdev.conf ${D}${sysconfdir}/
 	fi
 


### PR DESCRIPTION
Make sure /etc is created, even if no other /etc using USE flags are
enabled.

Signed-off-by: Esben Haabendal <esben@haabendal.dk>