### PR TITLE
Net snmp old stable

### DIFF
--- a/recipes/net-snmp/net-snmp.inc
+++ b/recipes/net-snmp/net-snmp.inc
@@ -55,7 +55,7 @@ DEPENDS_${PN}-agentxtrap += "libnetsnmpmibs libnetsnmpagent"
 RDEPENDS_${PN}-agentxtrap += "libnetsnmpmibs libnetsnmpagent"
 
 PACKAGES =+ "${PN}-mibs ${PN}-client ${PN}-server"
-DEPENDS_${PN}-server += "libnetsnmptrapd libnetsnmpmibs libnetsnmpagent libnetsnmp"
+DEPENDS_${PN}-server += "libc libcrypto libdl libnetsnmptrapd libnetsnmpmibs libnetsnmpagent libnetsnmp"
 RDEPENDS_${PN}-server += "libnetsnmptrapd libnetsnmpmibs libnetsnmpagent libnetsnmp"
 DEPENDS_${PN}-client += "${AUTO_PACKAGE_UTILS_PROVIDES}"
 RDEPENDS_${PN}-client += "${AUTO_PACKAGE_UTILS_PROVIDES}"

--- a/recipes/net-snmp/net-snmp.inc
+++ b/recipes/net-snmp/net-snmp.inc
@@ -6,7 +6,7 @@ COMPATIBLE_HOST_ARCHS = ".*linux"
 
 DEPENDS = "openssl"
 
-inherit autotools-autoreconf sysvinit siteinfo
+inherit sysvinit siteinfo
 
 require conf/fetch/sourceforge.conf
 SRC_URI = "${SOURCEFORGE_MIRROR}/net-snmp/net-snmp-${PV}.tar.gz"

--- a/recipes/net-snmp/net-snmp_5.4.5.pre1.oe
+++ b/recipes/net-snmp/net-snmp_5.4.5.pre1.oe
@@ -1,0 +1,26 @@
+#
+# 5.4.x LTS, supported by net-snmp.org
+#
+require net-snmp.inc
+inherit autotools c c++
+
+EXTRA_OECONF += "${@['--with-endianness=little', '--with-endianness=big']['${HOST_ENDIAN}'=='b']}"
+
+EXTRA_OECONF += "--disable-embedded-perl --with-perl-modules=no"
+EXTRA_OEMAKE = "INSTALL_PREFIX=${D}"
+
+AUTO_PACKAGE_UTILS = "\
+ encode_keychange fixproc ipf-mod.pl \
+ snmpbulkget snmpbulkwalk\
+ snmpcheck snmpconf snmpdelta snmpdf snmpget snmpgetnext\
+ snmpinform snmptrap snmpnetstat snmpset snmpstatus snmptable\
+ snmpusm snmpvacm snmpwalk tkmib snmptest snmptranslate \
+ traptoemail mib2c mib2c-update net-snmp-config"
+
+DEPENDS_${PN}-server += "libm libnetsnmphelpers"
+RDEPENDS_${PN}-server += "libnetsnmphelpers"
+AUTO_PACKAGE_UTILS_DEPENDS += "libm"
+DEPENDS_${PN}-libnetsnmphelpers += "libnetsnmp libnetsnmpagent"
+RDEPENDS_${PN}-libnetsnmphelpers2 += "libnetsnmp libnetsnmpagent"
+DEPENDS_${PN}-libnetsnmpmibs += "libnetsnmphelpers"
+RDEPENDS_${PN}-libnetsnmpmibs += "libnetsnmphelpers"

--- a/recipes/net-snmp/net-snmp_5.4.5.pre1.oe.sig
+++ b/recipes/net-snmp/net-snmp_5.4.5.pre1.oe.sig
@@ -1,0 +1,1 @@
+4ccbf14fc47d2e75dd21f45a973ccd7694785a86  net-snmp-5.4.5.pre1.tar.gz

--- a/recipes/net-snmp/net-snmp_5.7.3.oe
+++ b/recipes/net-snmp/net-snmp_5.7.3.oe
@@ -1,4 +1,5 @@
 require net-snmp.inc
+inherit autotools-autoreconf
 
 EXTRA_OECONF += "--disable-embedded-perl --with-perl-modules=no"
 EXTRA_OEMAKE = "INSTALL_PREFIX=${D}"


### PR DESCRIPTION
According to http://www.net-snmp.org/dev/schedule.html the net-snmp 5.4.x is a long term stable branch. Still maintained. Adding the pre1 release instead of the 5.4.4 release as many/all patches from that branch seems usefull/needed.
Upstream git branch for 5.4.x (V5-4-patches) is found here: http://sourceforge.net/p/net-snmp/code/ci/V5-4-patches/tree/