### PR TITLE
u-boot-tools: Support FIT image creation

### DIFF
--- a/recipes/u-boot/u-boot-tools.inc
+++ b/recipes/u-boot/u-boot-tools.inc
@@ -73,5 +73,8 @@ PACKAGES =+ "${PN}-env"
 FILES_${PN}-env = "${bindir}/fw_*env"
 PROVIDES_${PN}-env = "util/fw_printenv util/fw_setenv"
 
+DEPENDS_${PN}-mkimage += "dtc"
+RDEPENDS_${PN}-mkimage += "dtc"
+
 PACKAGES =+ "${PN}-gdb"
 FILES_${PN}-gdb = "${bindir}/gdb*"


### PR DESCRIPTION
Re-apply the addition of FIT image support.  It was added in PR #43 and
silently dropped in PR #244.

Signed-off-by: Esben Haabendal <esben@haabendal.dk>
(cherry picked from commit 00e1ff920644bec4ffe2222c5cd045ccc7212370)