### PR TITLE
kexec-tools: distclean no longer removes config.h.in

### DIFF
--- a/recipes/kexec-tools/kexec-tools-2.0.10/autotools.patch
+++ b/recipes/kexec-tools/kexec-tools-2.0.10/autotools.patch
@@ -5,7 +5,7 @@
  dist-clean: clean
  	$(RM) -f config.log config.status config.cache Makefile include/config.h
 -	$(RM) -f include/config.h.in configure $(SPEC)
-+	$(RM) -f include/config.h.in $(SPEC)
++	$(RM) -f $(SPEC)
  	$(RM) -rf autom4te.cache
  
  install: $(TARGETS)


### PR DESCRIPTION
Signed-off-by: Sean Nyekjaer <sean.nyekjaer@prevas.dk>