### PR TITLE
busybox: Fixup USE_busybox_feature_mount_loop

### DIFF
--- a/recipes/busybox/busybox-configure.inc
+++ b/recipes/busybox/busybox-configure.inc
@@ -770,9 +770,6 @@ BUSYBOX_SIMPLE_USE_FLAGS += "rdate:util/"
 # USE flag: enable swaponoff utility
 BUSYBOX_SIMPLE_USE_FLAGS += "swaponoff:util/"
 
-# USE flag: enable feature mount loop
-BUSYBOX_SIMPLE_USE_FLAGS += "feature_mount_loop"
-
 # USE flag: enable sfdisk
 BUSYBOX_SIMPLE_USE_FLAGS += "sfdisk:util/"
 


### PR DESCRIPTION
In d552158 and fd1f2c3, a new specification of this flag was added,
while the the old one was left in recipe.  The old specification is
processed last, and the result has been that the flag has been enabled
by default (as specified in the new specification), while
CONFIG_FEATURE_MOUNT_LOOP_CREATE was not enabled.

This change removed the old specification, and the visible change is
that CONFIG_FEATURE_MOUNT_LOOP_CREATE is now (also) enabled by the flag.

Signed-off-by: Esben Haabendal <esben@haabendal.dk>