### PR TITLE
openssh: change home dir and shell for sshd user

### DIFF
--- a/recipes/openssh/files/passwd
+++ b/recipes/openssh/files/passwd
@@ -1,1 +1,1 @@
-sshd:*:74:74::/home/sshd:/bin/sh
+sshd:*:74:74::/var/run/sshd:/bin/false


### PR DESCRIPTION
The directory /home/sshd presumably doesn't exist, so set it to
/var/run/sshd which is in any case the working directory for sshd
(it's created by the init script). Also, it doesn't make sense to log
in as sshd, so change its shell to /bin/false.