### PR TITLE
curl: fix libcurl-dev DEPENDS for libcurl

### DIFF
--- a/recipes/curl/curl.inc
+++ b/recipes/curl/curl.inc
@@ -45,8 +45,8 @@ EXTRA_OECONF_SSH = "--disable-ssh"
 EXTRA_OECONF_IDN:USE_curl_idn = "--with-libssh2"
 AUTO_PACKAGE_UTILS = "curl curl-config"
 
-DEPENDS_${PN} = "libc libgcc"
-RDEPENDS_${PN} = "libc libgcc"
+DEPENDS_${PN} += "libc libgcc"
+RDEPENDS_${PN} += "libc libgcc"
 DEPENDS_${PN}-curl = "libc libcurl"
 RDEPENDS_${PN}-curl = "libc libcurl"
 


### PR DESCRIPTION
When inheriting library, one must be carefull to not overwrite DEPENDS,
as library.oeclass sets up the library dependency for ${PN}-dev.

Fix this in the curl recipe by appending to DEPENDS instead of assigning
to it.