### PR TITLE
c-ares: new recipe

### DIFF
--- a/recipes/c-ares/c-ares-1.10.0/0001-deps-provide-TXT-chunk-info-in-c-ares.patch
+++ b/recipes/c-ares/c-ares-1.10.0/0001-deps-provide-TXT-chunk-info-in-c-ares.patch
@@ -1,0 +1,62 @@
+From a60a9b0dbd064cd70de9400ad47421c19d29b021 Mon Sep 17 00:00:00 2001
+From: Fedor Indutny <fedor@indutny.com>
+Date: Fri, 28 Mar 2014 00:09:20 +0400
+Subject: [PATCH] deps: provide TXT chunk info in c-ares
+
+Provide more information in `ares_txt_reply` to coalesce chunks from the
+same record into one string.
+
+upstream-status: unappropriate - needed for nodejs only
+
+---
+ ares.h             |  2 ++
+ ares_parse_txt_reply.c |  5 +++--
+ 4 files changed, 22 insertions(+), 6 deletions(-)
+
+diff --git a/ares.h b/ares.h
+index 3d0f9cf..3091064 100644
+--- a/ares.h
++++ b/ares.h
+@@ -520,6 +520,8 @@ struct ares_txt_reply {
+   struct ares_txt_reply  *next;
+   unsigned char          *txt;
+   size_t                  length;  /* length excludes null termination */
++  unsigned char           record_start;  /* 1 - if start of new record
++                                          * 0 - if a chunk in the same record */
+ };
+ 
+ struct ares_naptr_reply {
+diff --git a/ares_parse_txt_reply.c b/ares_parse_txt_reply.c
+index 981db4c..dabf73c 100644
+--- a/ares_parse_txt_reply.c
++++ b/ares_parse_txt_reply.c
+@@ -133,8 +133,6 @@ ares_parse_txt_reply (const unsigned char *abuf, int alen,
+                   break;
+                 }
+ 
+-              ++strptr;
+-
+               /* Allocate storage for this TXT answer appending it to the list */
+               txt_curr = ares_malloc_data(ARES_DATATYPE_TXT_REPLY);
+               if (!txt_curr)
+@@ -152,6 +150,7 @@ ares_parse_txt_reply (const unsigned char *abuf, int alen,
+                 }
+               txt_last = txt_curr;
+ 
++              txt_curr->record_start = strptr == aptr;
+               txt_curr->length = substr_len;
+               txt_curr->txt = malloc (substr_len + 1/* Including null byte */);
+               if (txt_curr->txt == NULL)
+@@ -159,6 +158,8 @@ ares_parse_txt_reply (const unsigned char *abuf, int alen,
+                   status = ARES_ENOMEM;
+                   break;
+                 }
++
++              ++strptr;
+               memcpy ((char *) txt_curr->txt, strptr, substr_len);
+ 
+               /* Make sure we NULL-terminate */
+ 
+-- 
+2.6.1
+

--- a/recipes/c-ares/c-ares.inc
+++ b/recipes/c-ares/c-ares.inc
@@ -1,0 +1,15 @@
+DESCRIPTION = "c-ares is a C library for asynchronous DNS requests (including name resolves)"
+LICENSE = "MIT"
+RECIPE_TYPES = "machine sdk native"
+
+inherit c autotools library
+
+SRC_URI  = "http://c-ares.haxx.se/download/c-ares-${PV}.tar.gz"
+SRC_URI += "file://0001-deps-provide-TXT-chunk-info-in-c-ares.patch "
+
+LIBRARY_NAME="libcares"
+LIBRARY_VERSION = "2"
+DEPENDS_${PN} = "libc"
+RDEPENDS_${PN} = "libc"
+
+BUILD_CFLAGS = "${BUILD_CFLAGS_OPT}"

--- a/recipes/c-ares/c-ares_1.10.0.oe
+++ b/recipes/c-ares/c-ares_1.10.0.oe
@@ -1,0 +1,1 @@
+require ${PN}.inc

--- a/recipes/c-ares/c-ares_1.10.0.oe.sig
+++ b/recipes/c-ares/c-ares_1.10.0.oe.sig
@@ -1,0 +1,1 @@
+e44e6575d5af99cb3a38461486e1ee8b49810eb5  c-ares-1.10.0.tar.gz


### PR DESCRIPTION
Add a recipe for the c-ares library used for async dns lookups. This is
needed to build nodejs, and thus we add a nodejs patch to make it
compatible.

The patch to make nodejs happy about record_start member of tx-structs
is required for all targets.

Explicitly set CFLAGS to avoid failing configure due to U_FORTIFY_SOURCE
not being specified in CPPFLAGS only.