### PR TITLE
openssl: disable parallel build for do_install

### DIFF
--- a/recipes/openssl/openssl.inc
+++ b/recipes/openssl/openssl.inc
@@ -95,7 +95,7 @@ do_compile () {
 }
 
 do_install () {
-	oe_runmake INSTALL_PREFIX="${D}" MANDIR="${mandir}" install
+	oe_runmake -j1 INSTALL_PREFIX="${D}" MANDIR="${mandir}" install
 
 	# On x86_64, move lib/* to lib64
 	if [ "${libdir}" != "${prefix}/lib" ]


### PR DESCRIPTION
Despite the buildbot apparently succeeding in building
920f96645787f9360dcf94131be885fedb6fac00, parallel building of openssl
is still broken.

Two of the five machine builds at
http://buildbot.oe-lite.org/builders/core/builds/263 failed at the
do_install part of the openssl recipe, and when trying to reproduce
locally, I found that it fails the same way using current master of
both base and core (9a22db1fcf4afe3f783929037ecb388944ce289f and
3fae0aed44ef844caee6f361fc564f2d0428cbf7, respectively).

Since parallel do_compile appararently works fine, this is an attempt
to hooking into just do_install and disabling it there. It does rely
on make grokking -j, but any make implementation not supporting that
should be shot and moved to /dev/null.