### PR TITLE
pkg-config: update src uri

### DIFF
--- a/recipes/pkg-config/pkg-config.inc
+++ b/recipes/pkg-config/pkg-config.inc
@@ -13,7 +13,7 @@ DEPENDS = " libglib"
 DEPENDS:>HOST_LIBC_glibc = " libdl libpthread"
 DEPENDS:>HOST_LIBC_uclibc = " libdl libpthread"
 
-SRC_URI = "http://pkgconfig.freedesktop.org/releases/pkg-config-${PV}.tar.gz"
+SRC_URI = "https://pkgconfig.freedesktop.org/releases/pkg-config-${PV}.tar.gz"
 
 SRC_URI += "file://common.site file://host_cpu.site"
 SRC_HOST_SITEFILES = "${SRCDIR}/common.site ${SRCDIR}/host_cpu.site"


### PR DESCRIPTION
The official pkg-config mirror has moved to https://, and emits an HTTP
301 when connecting to http://, which urlgrabber fails to follow.

Fix this by using https:// explicitly in the SRC_URI