### PR TITLE
u-boot-tools: add patch to fix compilation on recent compilers

### DIFF
--- a/recipes/u-boot/u-boot-tools-2015.10/0001-tools-env-include-compiler.h.patch
+++ b/recipes/u-boot/u-boot-tools-2015.10/0001-tools-env-include-compiler.h.patch
@@ -1,0 +1,28 @@
+From 69bf2d2fafe64349be3c3ef1256e3c68f812bb25 Mon Sep 17 00:00:00 2001
+From: Peter Robinson <pbrobinson@gmail.com>
+Date: Wed, 9 Dec 2015 07:15:33 +0000
+Subject: [PATCH] tools: env: include compiler.h
+
+With gcc 5.2 and later we get a bunch of "error: unknown type name" for
+'uint8_t', 'uint32_t' and friends.
+
+Signed-off-by: Peter Robinson <pbrobinson@gmail.com>
+---
+ tools/env/fw_env.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/tools/env/fw_env.c b/tools/env/fw_env.c
+index ba11f77..39f7333 100644
+--- a/tools/env/fw_env.c
++++ b/tools/env/fw_env.c
+@@ -10,6 +10,7 @@
+ 
+ #define _GNU_SOURCE
+ 
++#include <compiler.h>
+ #include <errno.h>
+ #include <env_flags.h>
+ #include <fcntl.h>
+-- 
+2.8.3
+

--- a/recipes/u-boot/u-boot-tools_2015.10.oe
+++ b/recipes/u-boot/u-boot-tools_2015.10.oe
@@ -5,3 +5,4 @@ require ${PN}.inc
 
 SRC_URI = "ftp://ftp.denx.de/pub/u-boot/u-boot-${PV}.tar.bz2"
 SRC_URI += "file://defconfig.patch"
+SRC_URI += "file://0001-tools-env-include-compiler.h.patch"


### PR DESCRIPTION
Backport a fix from upstream u-boot to fix compilation on recent
compilers.

Without this, the following error occurs (among others):

  HOSTCC  tools/env/ctype.o
tools/env/fw_env.c:54:2: error: unknown type name 'uint8_t'
  uint8_t mtd_type;  /* type of the MTD device */
  ^