### PR TITLE
glib: fix autoreconf on recent autotools

### DIFF
--- a/recipes/glib/glib-2.44.0/001-fix-error-wont-overwrite-defined-macro.patch
+++ b/recipes/glib/glib-2.44.0/001-fix-error-wont-overwrite-defined-macro.patch
@@ -1,0 +1,22 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: aquiles2k <aj@elane2k.com>
+Date: Wed, 6 Apr 2016 22:39:53 +0300
+Subject: [PATCH] fix error "won't overwrite defined macro" on OSX
+
+See https://github.com/mxe/mxe/issues/1281
+
+diff --git a/m4macros/glib-gettext.m4 b/m4macros/glib-gettext.m4
+index 1111111..2222222 100644
+--- a/m4macros/glib-gettext.m4
++++ b/m4macros/glib-gettext.m4
+@@ -36,8 +36,8 @@ dnl We go to great lengths to make sure that aclocal won't
+ dnl try to pull in the installed version of these macros
+ dnl when running aclocal in the glib directory.
+ dnl
+-m4_copy([AC_DEFUN],[glib_DEFUN])
+-m4_copy([AC_REQUIRE],[glib_REQUIRE])
++m4_copy_force([AC_DEFUN],[glib_DEFUN])
++m4_copy_force([AC_REQUIRE],[glib_REQUIRE])
+ dnl
+ dnl At the end, if we're not within glib, we'll define the public
+ dnl definitions in terms of our private definitions.

--- a/recipes/glib/glib_2.44.0.oe
+++ b/recipes/glib/glib_2.44.0.oe
@@ -6,6 +6,7 @@ require ${PN}.inc
 SRC_URI += "file://001-automake-compat.patch"
 inherit autotools-autoreconf
 SRC_URI += "file://100-fix-gio-linking.patch"
+SRC_URI += "file://001-fix-error-wont-overwrite-defined-macro.patch"
 
 SRC_URI:>HOST_LIBC_mingw = " file://libtool-bindir.patch"
 export sharedlibdir


### PR DESCRIPTION
Without this patch, autoreconf refuses to overwrite AC_DEFUN and
AC_REQUIRE.

autoreconf is needed to fix glibs calling of version specific automakes
during build (automake-1.14), when other versions are installed on the
system (e.g. automake-1.15 on ubuntu-16.04).