### PR TITLE
pcre: create binconfig-recipe instead of inheriting binconfig class

### DIFF
--- a/recipes/pcre/pcre-binconfig.oe
+++ b/recipes/pcre/pcre-binconfig.oe
@@ -1,0 +1,10 @@
+DESCRIPTION = "Recipe to provide a symlink to machine:pcre-config in stage/cross/bin/"
+LICENSE = "MIT"
+
+RECIPE_TYPES = "cross"
+FILES_${PN} = "${bindir}"
+
+do_install() {
+    install -d ${D}${bindir}
+    ln -s ../../machine${machine_bindir} ${D}${bindir}/pcre-config
+}

--- a/recipes/pcre/pcre.inc
+++ b/recipes/pcre/pcre.inc
@@ -10,7 +10,7 @@ HOMEPAGE = "http://www.pcre.org/"
 
 RECIPE_TYPES = "native machine sdk"
 
-inherit c++ autotools-autoreconf binconfig pkgconfig
+inherit c++ autotools-autoreconf pkgconfig
 
 require conf/fetch/sourceforge.conf
 SRC_URI = "${SOURCEFORGE_MIRROR}/project/${PN}/${PN}/${PV}/${P}.tar.gz"
@@ -53,4 +53,4 @@ AUTO_PACKAGE_LIBS_PCPREFIX = "lib"
 AUTO_PACKAGE_LIBS_DEV_DEPENDS = "${PN}-dev_${PV}"
 DEPENDS_${PN}-libpcreposix = "libpcre libc"
 DEPENDS_${PN}-libpcrecpp = "libpcre libc libm libgcc libstdc++"
-DEPENDS_${PN}-libpcre = "libc"
+DEPENDS_${PN}-libpcre = "libc cross:pcre-binconfig"


### PR DESCRIPTION
The pcre package creates a pcre-config script used by dependent packages
during their configure step. The this shell script is created in machine
context, it must be made available to dependent packages during their
stage step.

Until now, this was done by letting the pcre recipe inherit the
binconfig class, which adds a call to binconfig_stage_fixup() during the
dependent stage step. However, binconfig_stage_fixup() symlinks into
./stage/cross/bin/, which is not "allowed" in the stage fixup functions.
(They should only touch ./stage.unpack/ and not ./stage ).

Also, the symlink-during-stage fixup approach might fail as
./stage/cross/bin is not guarenteed to be created when
binconfig_stage_fixup() is called.

Fix this mess by creating a whole new recipe (pcre-binconfig) which
installs the symlink in cross context, and add is a dependency to the
libpcre package.