### PR TITLE
libunwind: added version 1.2-rc1

### DIFF
--- a/recipes/libunwind/libunwind.inc
+++ b/recipes/libunwind/libunwind.inc
@@ -1,0 +1,27 @@
+DESCRIPTION = "a portable and efficient C programming interface (API) to determine the call-chain of a program"
+LICENSE = "MIT"
+
+RECIPE_TYPES = "machine native"
+
+COMPATIBLE_HOST_ARCHS = ".*linux"
+
+inherit autotools-autoreconf auto-package-libs library
+
+SRC_URI = "git://git.sv.gnu.org/libunwind.git;tag=v${PV}"
+S = "${SRCDIR}/libunwind"
+
+AUTO_PACKAGE_LIBS = "arm setjmp coredump generic ptrace"
+
+DEPENDS_${PN} += "ld-so libc libgcc-s libunwind-arm"
+RDEPENDS_${PN} += "ld-so libc libgcc-s libunwind-arm"
+PROVIDES_${PN} = "libunwind-8 libunwind"
+
+DEPENDS_${PN}-libptrace += "libc libgcc-s"
+RDEPENDS_${PN}-libptrace += "libc libgcc-s"
+PROVIDES_${PN}-libptrace += "libunwind-ptrace libunwind-ptrace-0"
+PROVIDES_${PN}-libptrace[qa] = "allow-missing-soname:libptrace"
+FILES_${PN}-libptrace = "${sharedlibdir}/libunwind-ptrace.so*"
+FILES_${PN}-libarm = "${sharedlibdir}/libunwind-arm.so*"
+FILES_${PN}-libsetjmp = "${sharedlibdir}/libunwind-setjmp.so*"
+FILES_${PN}-libcoredump = "${sharedlibdir}/libunwind-coredump.so*"
+FILES_${PN}-libgeneric = "${sharedlibdir}/libunwind-generic.so*"

--- a/recipes/libunwind/libunwind_1.2-rc1.oe
+++ b/recipes/libunwind/libunwind_1.2-rc1.oe
@@ -1,0 +1,1 @@
+require libunwind.inc

--- a/recipes/libunwind/libunwind_1.2-rc1.oe.sig
+++ b/recipes/libunwind/libunwind_1.2-rc1.oe.sig
@@ -1,0 +1,1 @@
+c56fb8f99ed88bea006baada12b8577bf771ad14  git://git.sv.gnu.org/libunwind.git;tag=v1.2-rc1


### PR DESCRIPTION
The reason for adding a this rc1, is develepment is stalled a long time ago
before aarch64 supprt etc...

Signed-off-by: Sean Nyekjaer <sean.nyekjaer@prevas.dk>