### PR TITLE
libunwind: make it a little neater

### DIFF
--- a/recipes/libunwind/libunwind.inc
+++ b/recipes/libunwind/libunwind.inc
@@ -1,27 +1,29 @@
 DESCRIPTION = "a portable and efficient C programming interface (API) to determine the call-chain of a program"
 LICENSE = "MIT"
 
-RECIPE_TYPES = "machine native"
+RECIPE_TYPES = "machine native sdk"
 
-COMPATIBLE_HOST_ARCHS = ".*linux"
+COMPATIBLE_HOST_ARCHS = "arm-.*linux"
 
 inherit autotools-autoreconf auto-package-libs library
 
 SRC_URI = "git://git.sv.gnu.org/libunwind.git;tag=v${PV}"
 S = "${SRCDIR}/libunwind"
 
-AUTO_PACKAGE_LIBS = "arm setjmp coredump generic ptrace"
+AUTO_PACKAGE_LIBS = "arm setjmp coredump ptrace"
 
-DEPENDS_${PN} += "ld-so libc libgcc-s libunwind-arm"
-RDEPENDS_${PN} += "ld-so libc libgcc-s libunwind-arm"
-PROVIDES_${PN} = "libunwind-8 libunwind"
+AUTO_PACKAGE_LIBS_DEPENDS = "libc libgcc ${PN}"
+AUTO_PACKAGE_LIBS_RDEPENDS = "libc libgcc ${PN}"
 
-DEPENDS_${PN}-libptrace += "libc libgcc-s"
-RDEPENDS_${PN}-libptrace += "libc libgcc-s"
-PROVIDES_${PN}-libptrace += "libunwind-ptrace libunwind-ptrace-0"
-PROVIDES_${PN}-libptrace[qa] = "allow-missing-soname:libptrace"
-FILES_${PN}-libptrace = "${sharedlibdir}/libunwind-ptrace.so*"
-FILES_${PN}-libarm = "${sharedlibdir}/libunwind-arm.so*"
-FILES_${PN}-libsetjmp = "${sharedlibdir}/libunwind-setjmp.so*"
-FILES_${PN}-libcoredump = "${sharedlibdir}/libunwind-coredump.so*"
-FILES_${PN}-libgeneric = "${sharedlibdir}/libunwind-generic.so*"
+AUTO_PACKAGE_LIBS_PROVIDEPREFIX = "${PN}-"
+AUTO_PACKAGE_LIBS_PKGPREFIX = ""
+AUTO_PACKAGE_LIBS_LIBPREFIX = "${PN}-"
+
+DEPENDS_${PN} += "ld-so libc libgcc"
+RDEPENDS_${PN} += "ld-so libc libgcc"
+
+DEPENDS_${PN}-setjmp += "libunwind libunwind-arm"
+RDEPENDS_${PN}-setjmp += "libunwind libunwind-arm"
+
+PACKAGES += "${PN}-full"
+RDEPENDS_${PN}-full += "${LIBS_AUTO_RPACKAGES}"

--- a/recipes/libunwind/libunwind_1.2-rc1.oe
+++ b/recipes/libunwind/libunwind_1.2-rc1.oe
@@ -1,1 +1,7 @@
 require libunwind.inc
+
+LIBRARY_VERSION = "8"
+LIBRARY_VERSION_${PN}-arm = "8"
+LIBRARY_VERSION_${PN}-coredump = "0"
+LIBRARY_VERSION_${PN}-ptrace = "0"
+LIBRARY_VERSION_${PN}-setjmp = "0"


### PR DESCRIPTION
Utilizing the new AUTO_PACKAGE_LIBS_LIBPREFIX, along with the existing
PROVIDEPREFIX and PKGPREFIX, we can arrange that the recipe generates
packages "libunwind-setjmp", "libunwind-coredump", etc. which provide
the .so files of the same name.

While at it, make sure this is only compatible with arm for now. The
proper fix would be to extract the proper arch string and use that
instead of the hardcoded "arm".

Another nice-to-have is a use-flag for enabling lzma.

For now, let's just be content with the fact the packageqa passes,
whatever that means.

Signed-off-by: Rasmus Villemoes <rasmus.villemoes@prevas.dk>