### PR TITLE
busybox: stty: Allow baudrates up to 4000000

### DIFF
--- a/recipes/busybox/busybox.inc
+++ b/recipes/busybox/busybox.inc
@@ -40,6 +40,7 @@ SRC_URI += "\
 	file://busybox-ifplugd.action \
 	file://busybox-ifplugd.conf \
 	file://busybox-dnsd \
+	file://speed_table.patch \
 "
 
 PACKAGES:<USE_busybox_udhcpc = "${PN}-udhcpc-scripts "

--- a/recipes/busybox/files/speed_table.patch
+++ b/recipes/busybox/files/speed_table.patch
@@ -1,0 +1,40 @@
+--- busybox-1.23.2/libbb/speed_table.c.org	2016-06-15 13:17:31.029138573 +0200
++++ busybox-1.23.2/libbb/speed_table.c	2016-06-15 13:34:26.043647343 +0200
+@@ -59,6 +59,27 @@
+ #ifdef B921600
+ 	{B921600, 921600/256 + 0x8000U},
+ #endif
++#ifdef B1152000
++	{B1152000, 1152000/256 + 0x8000U},
++#endif
++#ifdef B1500000
++	{B1500000, 1500000/250 + 0x4000U},
++#endif
++#ifdef B2000000
++        {B2000000, 2000000/250 + 0x4000U},
++#endif
++#ifdef B2500000
++	{B2500000, 2500000/250 + 0x4000U},
++#endif
++#ifdef B3000000
++	{B3000000, 3000000/250 + 0x4000U},
++#endif
++#ifdef B3500000
++	{B3500000, 3500000/250 + 0x4000U},
++#endif
++#ifdef B4000000
++	{B4000000, 4000000/256 + 0x8000U},
++#endif
+ };
+ 
+ enum { NUM_SPEEDS = ARRAY_SIZE(speeds) };
+@@ -72,6 +93,9 @@
+ 			if (speeds[i].value & 0x8000U) {
+ 				return ((unsigned long) (speeds[i].value) & 0x7fffU) * 256;
+ 			}
++			if (speeds[i].value & 0x4000U) {
++				return ((unsigned long) (speeds[i].value) & 0x3fffU) * 250;
++			}
+ 			return speeds[i].value;
+ 		}
+ 	} while (++i < NUM_SPEEDS);


### PR DESCRIPTION
Probably due to memory usage the baudrate is coded to make it possible to
store it in a short.
This is done by dividing high baudrates by 256 (shift 8 bits) and raising
MSB to signal the division.
This way baudrates being dividable with 256 and not greater than 8388352
can be stored.

To make support for the 'odd' baudrates of 1500000, 2500000 etc bit 14
(MSB -1) has bin chosen to signal a divisor of 250.

Drawback is that coded max, after being divided by 256, must now not
exceed 0x3FFF causing maximum baudrate to be 4194048
or 4095750 for baudrates dividable by 250