### PR TITLE
dmalloc: make fix_ld hack more robust

### DIFF
--- a/recipes/dmalloc/dmalloc_5.5.2.oe
+++ b/recipes/dmalloc/dmalloc_5.5.2.oe
@@ -21,7 +21,7 @@ do_configure_conf() {
 
 do_compile[prefuncs] += "do_compile_fix_ld"
 do_compile_fix_ld() {
-    sed -i -e 's/ld \-G/${HOST_ARCH}-ld \-G/' ${S}/Makefile
+    sed -i -e 's/\tld \-G/\t${HOST_LD} \-G/' ${S}/Makefile
 }
 
 EXTRA_OEMAKE += " \


### PR DESCRIPTION
We sometimes see dmalloc failing to build due to a mysterious
duplicate cross compile prefix
(e.g. arm-926ejs-linux-gnueabi-arm-926ejs-linux-gnueabi-ld). This
string can appear in the Makefile if do_compile is run twice, since
the fix_ld hack is not idempotent.

I haven't found a way to reliably reproduce the actual problem, but
the wrong makefile is easy to reproduce:

  # from completely clean state
  oe bake dmalloc -y
  rm tmp/stamp/machine/arm-926ejs-linux-gnueabi/dmalloc-5.5.2/do_compile
  oe bake dmalloc -y
  less tmp/work/machine/arm-926ejs-linux-gnueabi/dmalloc-5.5.2/src/dmalloc-5.5.2/Makefile

But unfortunately, in this case, the second bake fails to fail, since
the rules containing those ld calls don't get used by make (everything
was already succesfully built). However, the buildbot definitely
experiences this from time to time, and I've also seen it locally
during an "oe bake world".

In any case, we can make the fix a little more robust by only
replacing "ld" if it's preceded by a tab character.