### PR TITLE
barebox: remove recipe

### DIFF
--- a/recipes/barebox/barebox.inc
+++ b/recipes/barebox/barebox.inc
@@ -1,3 +1,0 @@
-inherit barebox
-
-SRC_URI = "http://barebox.org/download/barebox-2012.02.0.tar.bz2"

--- a/recipes/barebox/barebox_2012.02.0.oe
+++ b/recipes/barebox/barebox_2012.02.0.oe
@@ -1,4 +1,0 @@
-require ${PN}.inc
-
-SRC_URI = "git://git.pengutronix.de/git/barebox.git;commit=238b7b1d99940a4fa0579adda026fdebd67ae243"
-S = "${SRCDIR}/barebox"

--- a/recipes/barebox/barebox_2012.02.0.oe.sig
+++ b/recipes/barebox/barebox_2012.02.0.oe.sig
@@ -1,1 +1,0 @@
-b3b35efa48f754aec775f75552368293fcda490e  barebox-2012.02.0.tar.bz2


### PR DESCRIPTION
The current barebox recipe is a little flaky (the .inc file points to
a version-specific SRC_URI, and the .oe file overrides that with a
SRC_URI pointing to a commit which is not v2012.02, but actually just
two commits shy of v2012.03). It also causes problems for at least one
downstream user of oe-lite (preventing "oe bake world" from even
parsing) because of the default dependency on the existence of a
barebox-defconfig recipe. Nuke it.