### PR TITLE
dmalloc: disable parallel make

### DIFF
--- a/recipes/dmalloc/dmalloc_5.5.2.oe
+++ b/recipes/dmalloc/dmalloc_5.5.2.oe
@@ -24,6 +24,8 @@ do_compile_fix_ld() {
     sed -i -e 's/\tld \-G/\t${HOST_LD} \-G/' ${S}/Makefile
 }
 
+PARALLEL_MAKE=""
+
 EXTRA_OEMAKE += " \
     cxx \
     cxxsl \


### PR DESCRIPTION
Observer with make -j8:

"
+ do_compile_make
+ '[' -e Makefile -o -e makefile ']'
+ oe_runmake
+ make -j8 cxx cxxsl threads threadssl threadscxx threadscxxsl utils shlib
rm -f dmalloc.h dmalloc.h.t

...

aarch64-cortexa53t-linux-gnu-gcc -O2 -fexpensive-optimizations \
-fomit-frame-pointer -frename-registers  -fPIC   -DHAVE_STDARG_H=1 \
-DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_UNISTD_H=1 -DHAVE_SYS_MMAN_H=1 \
-DHAVE_SYS_TYPES_H=1 -DHAVE_W32API_WINBASE_H=0 -DHAVE_W32API_WINDEF_H=0 \
-DHAVE_SYS_CYGWIN_H=0 -DHAVE_SIGNAL_H=1  -I. \
-I/build/tmp/work/machine/aarch64-cortexa53t-linux-gnu/dmalloc-5.5.2/src/dmalloc-5.5.2 \
 -c dmalloc_argv.c -o ./dmalloc_argv.o
/build/tmp/work/machine/aarch64-cortexa53t-linux-gnu/dmalloc-5.5.2/src/dmalloc-5.5.2/dmallocc.cc:41:21: \
fatal error: dmalloc.h: No such file or directory
compilation terminated.
make: *** [dmallocc.o] Error 1
make: *** Waiting for unfinished jobs....
mv dmalloc.h.t dmalloc.h
"