### PR TITLE
vsftpd: fix set_ftp_home postfunc

### DIFF
--- a/recipes/vsftpd/vsftpd.inc
+++ b/recipes/vsftpd/vsftpd.inc
@@ -59,10 +59,10 @@ do_install() {
 
 RECIPE_FLAGS += "ftp_home"
 DEFAULT_USE_ftp_home = "/home/ftp"
-do_install[postfuncs] += "do_install_set_ftp_home"
-do_install_set_ftp_home() {
+do_configure[postfuncs] += "do_configure_set_ftp_home"
+do_configure_set_ftp_home() {
 	sed -i -e "s|PLACEHOLDER_FTP_HOME|${USE_ftp_home}|" \
-		${D}${sysconfdir}/passwd.d/${PN}.1
+		${SRCDIR}/passwd
 }
 
 RECIPE_FLAGS += "vsftpd_sysvinit_start vsftpd_sysvinit_stop"


### PR DESCRIPTION
A change in passwd.oeclass means the copy of our passwd file is no
longer where this function expects it to be. Rather than just fixing
the path (which shouldn't contain a hard-coded passwd.d anyway), do
what mysql does and patch it in the SRCDIR before passwd.oeclass gets
its hands on it.