### PR TITLE
bind: fix wrong RDEPENDS variable

### DIFF
--- a/recipes/bind/bind.inc
+++ b/recipes/bind/bind.inc
@@ -9,7 +9,7 @@ inherit autotools sysvinit
 DEPENDS = "libssl libcrypto ${DEPENDS_LIBC}"
 DEPENDS_LIBC = "libdl"
 DEPENDS_LIBC:HOST_LIBC_mingw = ""
-RDEPENDS = "${PN}-config"
+RDEPENDS_${PN} = "${PN}-config"
 
 SRC_URI = "ftp://ftp.isc.org/isc/bind9/${PV}/${PN}-${PV}.tar.gz"
 


### PR DESCRIPTION
The RDEPENDS variable makes no sense without a trailing packagename (and
it screws up 'oe bake bind -t do_fetchall'. Fix it by adding the correct
'_${PN}'.