### PR TITLE
mysql: added compatible flag "gcc-older-than-6.x"

### DIFF
--- a/recipes/mysql/mysql-tools_5.6.13.oe
+++ b/recipes/mysql/mysql-tools_5.6.13.oe
@@ -11,6 +11,7 @@ SRC_URI += " file://gen_pfs_lex_token.patch "
 
 RECIPE_TYPES = "native"
 COMPATIBLE_HOST_ARCHS = ".*linux"
+COMPATIBLE_IF_FLAGS="gcc_older_than_6.x"
 
 inherit cmake c++
 

--- a/recipes/mysql/mysql_5.6.13.oe
+++ b/recipes/mysql/mysql_5.6.13.oe
@@ -7,6 +7,7 @@ SRC_URI += " file://srv_buff_size.patch"
 
 RECIPE_TYPES = "machine"
 COMPATIBLE_HOST_ARCHS = ".*linux"
+COMPATIBLE_IF_FLAGS="gcc_older_than_6.x"
 
 inherit cmake c++ pkgconfig
 

--- a/recipes/mysql/mysqludf-sys.oe
+++ b/recipes/mysql/mysqludf-sys.oe
@@ -11,6 +11,7 @@ S = "${SRCDIR}/lib_mysqludf_sys-master"
 
 DEPENDS += "mysql-dev"
 COMPATIBLE_HOST_ARCHS = ".*linux"
+COMPATIBLE_IF_FLAGS="gcc_older_than_6.x"
 
 CFLAGS += "-I${STAGE_DIR}/machine/usr/include -fPIC"
 export LIBDIR = "${D}/${libdir}"


### PR DESCRIPTION
GCC 6 series breaks this build.
If someone needs this functionality, they could add fx mariaDB

Signed-off-by: Sean Nyekjaer <sean.nyekjaer@prevas.dk>