### PR TITLE
gnupg: fix RDEPENDS setting

### DIFF
--- a/recipes/gnupg/gnupg.inc
+++ b/recipes/gnupg/gnupg.inc
@@ -26,7 +26,7 @@ do_install_post() {
 }
 
 # split out gpgv from main package
-RDEPENDS_gnupg = "gpgv"
+RDEPENDS_${PN} += "gpgv"
 PACKAGES =+ "gpgv"
 FILES_gpgv = "${bindir}/gpgv"
 


### PR DESCRIPTION
One would think that

  RDEPENDS_gnupg = "gpgv" # in gnupg.inc
  RDEPENDS_${PN} += "libc" # later, in gnupg_2.0.29.oe

would end up giving RDEPENDS_gnupg the value "gpgv libc". However:

$ oe show gnupg | grep ^RDEPENDS_gnupg=
RDEPENDS_gnupg='libc'

This is a consequence of how core_varname_expansion works and the fact
that for simple variable assignments, the varname is not expanded
immediately.