### PR TITLE
can-utils: Fix installation prefix

### DIFF
--- a/recipes/can-utils/can-utils.oe
+++ b/recipes/can-utils/can-utils.oe
@@ -10,4 +10,10 @@ S = "${SRCDIR}/can-utils"
 
 RDEPENDS_${PN} = "libc"
 
+export PREFIX="${exec_prefix}"
+do_configure[prefuncs] += "do_configure_prefix_from_env"
+do_configure_prefix_from_env() {
+	sed -i -e 's/^\(PREFIX = .*\)/#\1/' Makefile
+}
+
 FILES_${PN} += "/usr"


### PR DESCRIPTION
The upstream Makefile has PREFIX hard-coded to /usr/local