### PR TITLE
openssl: termio.h is not linux specific but it's libc specific

### DIFF
--- a/recipes/openssl/openssl.inc
+++ b/recipes/openssl/openssl.inc
@@ -18,7 +18,7 @@ DEPENDS_HOST_OS = "libdl"
 DEPENDS_HOST_OS:HOST_OS_mingw32 = ""
 
 CFLAG = "${@['-DL_ENDIAN', '-DB_ENDIAN']['${HOST_ENDIAN}'=='b']} ${HOST_CFLAGS}"
-CFLAG:>HOST_KERNEL_linux = " -DTERMIO"
+CFLAG:>HOST_LIBC_glibc = " -DTERMIO"
 
 CROSS:native = ""
 export WINDRES = "${CROSS}windres"


### PR DESCRIPTION
Signed-off-by: Sean Nyekjaer <sean.nyekjaer@prevas.dk>