### PR TITLE
util-linux: move specific glibc and uclibc depends to depends

### DIFF
--- a/recipes/util-linux/util-linux.inc
+++ b/recipes/util-linux/util-linux.inc
@@ -14,10 +14,7 @@ MI = "${@bb.data.getVar('PV', d, 1).split('-')[0].split('.')[1]}"
 UTIL_LINUX_EXTENTION ?= ".tar.bz2"
 SRC_URI = "${KERNELORG_MIRROR}/linux/utils/${PN}/v${MA}.${MI}/${P}${UTIL_LINUX_EXTENTION}"
 
-DEPENDS = "libc libz librt native:gettext"
-DEPENDS:>HOST_LIBC_glibc = " libutil libcrypt libtermcap"
-DEPENDS:>HOST_LIBC_uclibc = " libutil libcrypt libtermcap"
-
+DEPENDS = "libc libz librt native:gettext libutil libcrypt libtermcap"
 DEPENDS += "native:gettext-autopoint"
 
 EXTRA_OECONF = "\


### PR DESCRIPTION
All our current libc's depends on the same packages,
so remove this condition

Signed-off-by: Sean Nyekjaer <sean.nyekjaer@prevas.dk>