### PR TITLE
fuse: Fix build when running with mknod privileges

### DIFF
--- a/recipes/fuse/fuse.inc
+++ b/recipes/fuse/fuse.inc
@@ -12,6 +12,13 @@ SRC_URI = "${SOURCEFORGE_MIRROR}/fuse/fuse-${PV}.tar.gz"
 
 PACKAGES = "${PN}-dbg ${PN} ${PN}-doc"
 
+# Get rid of /dev/fuse (and /dev while at it), which will be created if run
+# with mknod privileges
+do_install_rm_dev() {
+	rm -rf ${D}/dev
+}
+do_install[postfuncs] += "do_install_rm_dev"
+
 DEPENDS_${PN} = "libc libpthread"
 RDEPENDS_${PN} = "libc libpthread"
 


### PR DESCRIPTION
Without this fix, you will end up creating ${D}/dev/fuse when building
with mknod privileges. And as /dev/fuse is not included in any package,
do_split barfs.

Yes, you probably shouldn't do this.  But if (when) done, there is no
good reason to fail in this odd way.

Signed-off-by: Esben Haabendal <esben@haabendal.dk>