### PR TITLE
busybox: fix groups emulation script

### DIFF
--- a/recipes/busybox/files/groups
+++ b/recipes/busybox/files/groups
@@ -1,2 +1,2 @@
 #!/bin/sh
-id -Gn
+id -Gn "$@"


### PR DESCRIPTION
Running "groups sshd" as root reveals the groups of the... root user!
Append the given arguments to the id invocation.
