### PR TITLE
libxml2: actually (try to) use oe-lite python

### DIFF
--- a/recipes/libxml/libxml2.inc
+++ b/recipes/libxml/libxml2.inc
@@ -52,11 +52,12 @@ def setup_python(d):
     pydir = " {}/python{}.{}".format(libdir, major, minor)
     d.set("PYDIR",pydir.strip())
 
-do_configure[prefunc] += "python_setup"
-python_setup() {
-    export PYTHONPATH=${BUILD_SYSROOT}/${PYDIR}
-    export PYTHONHOME=${TARGET_SYSROOT}${prefix}
-}
+PYTHONPATH = "${BUILD_SYSROOT}/${PYDIR}"
+PYTHONHOME = "${TARGET_SYSROOT}${prefix}"
+PYTHONPATH[emit] = "do_configure"
+PYTHONHOME[emit] = "do_configure"
+PYTHONPATH[export] = "1"
+PYTHONHOME[export] = "1"
 
 FILES_${PN}-python += "${PYDIR}/site-packages/libxml2mod.so \
 			   ${PYDIR}/site-packages/libxml2.py \


### PR DESCRIPTION
There are two reasons the python_setup function does nothing: It is
never run because of the prefuncS typo. And even if it did get run, it
would be in a different shell instance than where the do_configure
function runs.

Try to fix this by just defining the variables and setting proper
flags ensuring they're only emitted to the do_configure task.
