### PR TITLE
libnl: create m4 directory unconditionally

### DIFF
--- a/recipes/libnl/libnl_3.2.28.oe
+++ b/recipes/libnl/libnl_3.2.28.oe
@@ -23,6 +23,6 @@ LIBRARY_VERSION_${PN}-libnl = "22"
 do_autoreconf[prefuncs] += "do_autoreconf_prepend"
 do_autoreconf_prepend() {
 	for dir in doc ; do
-		mkdir $dir/m4
+		mkdir -p $dir/m4
 	done
 }


### PR DESCRIPTION
This fixes builds where the m4 directory already exits

Signed-off-by: Sean Nyekjaer <sean@nyekjaer.dk>