### PR TITLE
gmp.oe: add version 6.1.1 recipe

### DIFF
--- a/recipes/gmp/gmp_6.1.1.oe
+++ b/recipes/gmp/gmp_6.1.1.oe
@@ -1,0 +1,2 @@
+require ${PN}.inc
+LICENSE = "LGPL-3.0+"

--- a/recipes/gmp/gmp_6.1.1.oe.sig
+++ b/recipes/gmp/gmp_6.1.1.oe.sig
@@ -1,0 +1,1 @@
+4da491d63ef850a7662f41da27ad1ba99c2dbaa1  gmp-6.1.1.tar.xz


### PR DESCRIPTION
From https://github.com/oe-lite/core/pull/174

This version (among other things) adds support for thumb-less arm architecture.