### PR TITLE
Saner boolean use flag initializers

### DIFF
--- a/conf/distro/base.conf
+++ b/conf/distro/base.conf
@@ -4,7 +4,7 @@
 
 require conf/distro/core.conf
 
-DISTRO_USE_sysvinit = "1"
+DISTRO_USE_sysvinit = True
 
 PREFERRED_PROVIDER_linux-headers = "linux-headers"
 

--- a/recipes/bind/bind.inc
+++ b/recipes/bind/bind.inc
@@ -34,7 +34,7 @@ DEFAULT_USE_bind_sysvinit_start= "20"
 DEFAULT_USE_bind_sysvinit_stop = "20"
 
 RECIPE_FLAGS += "bind_openssl"
-DEFAULT_USE_bind_openssl = "1"
+DEFAULT_USE_bind_openssl = True
 EXTRA_OECONF += "${EXTRA_OECONF_OPENSSL}"
 EXTRA_OECONF_OPENSSL = " --without-openssl"
 EXTRA_OECONF_OPENSSL:USE_bind_openssl = ""

--- a/recipes/busybox/busybox-configure.inc
+++ b/recipes/busybox/busybox-configure.inc
@@ -59,7 +59,7 @@ def busybox_simple_use_flags(d):
 
 RECIPE_FLAGS += "busybox_init"
 # USE flag: Enable sysvinit utility (boolean)
-DEFAULT_USE_busybox_init = "1"
+DEFAULT_USE_busybox_init = True
 BUSYBOX_PROVIDES:>USE_busybox_init = " busybox-init sysvinit"
 DO_CONFIGURE_PREFUNCS:>USE_busybox_init = " do_configure_busybox_init"
 do_configure_busybox_init () {
@@ -75,7 +75,7 @@ do_configure_busybox_init () {
 
 RECIPE_FLAGS += "busybox_runit"
 # USE flag: enable runit utility
-DEFAULT_USE_busybox_runit = "0"
+DEFAULT_USE_busybox_runit = False
 BUSYBOX_PROVIDES:>USE_busybox_runit = " busybox-runit runit"
 DO_CONFIGURE_PREFUNCS:>USE_busybox_runit = " do_configure_busybox_runit"
 do_configure_busybox_runit () {
@@ -113,12 +113,12 @@ RECIPE_FLAGS += "busybox_mdev_splashutils_progress busybox_mdev_splashutils_msg"
 SPLASHUTILS_INITSCRIPTS:>USE_busybox_mdev += " busybox_mdev"
 DEFAULT_USE_busybox_mdev_splashutils_msg = "\"Starting Mdev\""
 RECIPE_FLAGS += "busybox_mdev_dash_s"
-DEFAULT_USE_busybox_mdev_dash_s = "1"
+DEFAULT_USE_busybox_mdev_dash_s = True
 
 RECIPE_FLAGS += "busybox_klogd \
         busybox_klogd_sysvinit_start busybox_klogd_conlevel"
 # USE flag: enable klogd daemon
-DEFAULT_USE_busybox_klogd = "1"
+DEFAULT_USE_busybox_klogd = True
 DEFAULT_USE_busybox_klogd_sysvinit_start = "22"
 # USE flag: console log level (default: LOG_WARNING)
 DEFAULT_USE_busybox_klogd_conlevel = "5"
@@ -142,21 +142,21 @@ RECIPE_FLAGS += "busybox_syslogd \
         busybox_syslogd_rotate_size busybox_syslogd_rotate_n \
         busybox_syslogd_log_level"
 # USE flag: enable syslogd daemon
-DEFAULT_USE_busybox_syslogd = "1"
+DEFAULT_USE_busybox_syslogd = True
 DEFAULT_USE_busybox_syslogd_sysvinit_start = "21"
 DEFAULT_USE_busybox_syslogd_sysvinit_stop  = "0"
 # USE flag: syslogd destination (default: to file /var/log/messages)
 DEFAULT_USE_busybox_syslogd_file = "-O /var/log/messages"
 # USE flag: enable syslogd IPC (circular buffer) support
-DEFAULT_USE_busybox_syslogd_ipc = "0"
+DEFAULT_USE_busybox_syslogd_ipc = False
 # USE flag: syslogd IPC buffer size, in kByte
 DEFAULT_USE_busybox_syslogd_ipc_bufsize = "16"
 # USE flag: enable remote syslogd support
-DEFAULT_USE_busybox_syslogd_remote = "0"
+DEFAULT_USE_busybox_syslogd_remote = False
 # USE flag: syslogd remote host (should be set to -R and optionally -L args)
 DEFAULT_USE_busybox_syslogd_remote_host = "0"
 # USE flag: enable syslogd log rotation support
-DEFAULT_USE_busybox_syslogd_rotate = "0"
+DEFAULT_USE_busybox_syslogd_rotate = False
 # USE flag: syslogd log rotation size (in kByte)
 DEFAULT_USE_busybox_syslogd_rotate_size = "200"
 # USE flag: number of rotated logfiles to keep
@@ -209,7 +209,7 @@ CONFIG_FEATURE_HWCLOCK_LONG_OPTIONS,\
 CONFIG_FEATURE_HWCLOCK_ADJTIME_FHS"
 
 RECIPE_FLAGS += "busybox_hwclock_sysvinit_start busybox_hwclock_sysvinit_stop"
-DEFAULT_USE_busybox_hwclock = "1"
+DEFAULT_USE_busybox_hwclock = True
 DEFAULT_USE_busybox_hwclock_sysvinit_start = "15"
 DEFAULT_USE_busybox_hwclock_sysvinit_stop  = "15"
 RECIPE_FLAGS += "busybox_hwclock_splashutils_progress busybox_hwclock_splashutils_msg"
@@ -263,7 +263,7 @@ RECIPE_FLAGS += "busybox_watchdog \
         busybox_watchdog_runit \
         busybox_watchdog_dev"
 # USE flag: enable watchdog support
-DEFAULT_USE_busybox_watchdog = "0"
+DEFAULT_USE_busybox_watchdog = False
 DEFAULT_USE_busybox_watchdog_sysvinit_start = "70"
 DEFAULT_USE_busybox_watchdog_sysvinit_stop  = "01"
 # USE flag: wathcdog device
@@ -286,10 +286,10 @@ RECIPE_FLAGS += "busybox_udhcpc \
                  busybox_udhcpc_ifupdown_cmd_options \
 "
 # USE flag: enable udhcp client
-DEFAULT_USE_busybox_udhcpc = "1"
+DEFAULT_USE_busybox_udhcpc = True
 DEFAULT_USE_busybox_udhcpc_ifupdown_cmd_options ="-R -n"
 # USE flag: enable RFC3397 support
-DEFAULT_USE_busybox_udhcpc_rfc3397 = "1"
+DEFAULT_USE_busybox_udhcpc_rfc3397 = True
 BUSYBOX_PROVIDES:>USE_busybox_udhcpc = " busybox-udhcpc dhcp-client"
 DO_CONFIGURE_PREFUNCS:>USE_busybox_udhcpc = " do_configure_busybox_udhcpc"
 do_configure_busybox_udhcpc () {
@@ -317,7 +317,7 @@ do_configure_busybox_dhclient () {
 
 RECIPE_FLAGS += "busybox_udhcpc6"
 # USE flag: enable udhcpc6 client
-DEFAULT_USE_busybox_udhcpc6 = "0"
+DEFAULT_USE_busybox_udhcpc6 = False
 BUSYBOX_PROVIDES:>USE_busybox_udhcpc6 = " busybox-udhcpc6 dhcp-client6"
 DO_CONFIGURE_PREFUNCS:>USE_busybox_udhcpc6 = " do_configure_busybox_udhcpc6"
 do_configure_busybox_udhcpc6 () {
@@ -331,7 +331,7 @@ do_configure_busybox_udhcpc6 () {
 RECIPE_FLAGS += "busybox_udhcpd \
         busybox_udhcpd_sysvinit_start busybox_udhcpd_sysvinit_stop"
 # USE flag: enable udhcp server
-DEFAULT_USE_busybox_udhcpd = "0"
+DEFAULT_USE_busybox_udhcpd = False
 DEFAULT_USE_busybox_udhcpd_sysvinit_start = "90"
 DEFAULT_USE_busybox_udhcpd_sysvinit_stop  = "90"
 BUSYBOX_PROVIDES:>USE_busybox_udhcpd = " busybox-udhcpd dhcp-server"
@@ -454,7 +454,7 @@ busybox_suid_root:USE_busybox_su = "1"
 
 RECIPE_FLAGS += "busybox_ash"
 # USE flag: enable ash shell
-DEFAULT_USE_busybox_ash = "1"
+DEFAULT_USE_busybox_ash = True
 # Run-time provides ash shell
 BUSYBOX_PROVIDES:>USE_busybox_ash += " busybox-ash sh getopts echo printf test"
 DO_CONFIGURE_PREFUNCS:>USE_busybox_ash = " do_configure_busybox_ash"
@@ -487,7 +487,7 @@ BUSYBOX_SIMPLE_USE_FLAGS += "sh_math_support_64"
 RECIPE_FLAGS += "busybox_hush"
 
 # USE flag: enable hush shell
-DEFAULT_USE_busybox_hush = "0"
+DEFAULT_USE_busybox_hush = False
 # Run-time provides hush shell
 BUSYBOX_PROVIDES:>USE_busybox_hush += " busybox-hush sh getopts echo printf test"
 DO_CONFIGURE_PREFUNCS:>USE_busybox_hush = " do_configure_busybox_hush"
@@ -1161,10 +1161,10 @@ BUSYBOX_SIMPLE_USE_FLAGS += "powertop:util/"
 
 # md5sum, sha1sum, sha256sum, sha512sum, sha3sum
 BUSYBOX_SIMPLE_USE_FLAGS += "md5sum:util/"
-DEFAULT_USE_busybox_md5sum = "1"
+DEFAULT_USE_busybox_md5sum = True
 BUSYBOX_SIMPLE_USE_FLAGS += "sha1sum:util/"
 BUSYBOX_SIMPLE_USE_FLAGS += "sha256sum:util/"
-DEFAULT_USE_busybox_sha256sum = "1"
+DEFAULT_USE_busybox_sha256sum = True
 BUSYBOX_SIMPLE_USE_FLAGS += "sha512sum:util/"
 BUSYBOX_SIMPLE_USE_FLAGS += "sha3sum:util/"
 

--- a/recipes/busybox/busybox-initramfs.inc
+++ b/recipes/busybox/busybox-initramfs.inc
@@ -5,16 +5,16 @@ RECIPE_USE_busybox_watchdog_sysvinit_start	= "70"
 # Cannot log to appfs
 RECIPE_USE_busybox_syslogd_file		= "-O /var/log/syslog"
 # And no reason to rotate logfiles
-RECIPE_USE_busybox_syslogd_rotate		= "0"
+RECIPE_USE_busybox_syslogd_rotate		= False
 
 # Get rid of additional cruft
-RECIPE_USE_busybox_cron			= "0"
-RECIPE_USE_busybox_hwclock_crontab		= "0"
-RECIPE_USE_busybox_ntpd			= "0"
+RECIPE_USE_busybox_cron			= False
+RECIPE_USE_busybox_hwclock_crontab		= False
+RECIPE_USE_busybox_ntpd			= False
 
-RECIPE_USE_busybox_mdev			= "1"
-RECIPE_USE_busybox_ip	= "1"
-RECIPE_USE_busybox_feature_ifupdown_ip_builtin	= "1"
+RECIPE_USE_busybox_mdev			= True
+RECIPE_USE_busybox_ip	= True
+RECIPE_USE_busybox_feature_ifupdown_ip_builtin	= True
 
 
 # Don't add all the RPROVIDES, as they should be picked up from main

--- a/recipes/busybox/busybox.inc
+++ b/recipes/busybox/busybox.inc
@@ -46,7 +46,7 @@ SRC_URI += "\
 PACKAGES:<USE_busybox_udhcpc = "${PN}-udhcpc-scripts "
 
 RECIPE_FLAGS += "busybox_init_shutdown_umount"
-DEFAULT_USE_busybox_init_shutdown_umount = "1"
+DEFAULT_USE_busybox_init_shutdown_umount = True
 SRC_URI:>USE_busybox_init_shutdown_umount = " file://init-shutdown-umount.patch"
 
 LIB_DEPENDS = "libc libm libcrypt"

--- a/recipes/cryptsetup/cryptsetup_1.6.2.oe
+++ b/recipes/cryptsetup/cryptsetup_1.6.2.oe
@@ -13,19 +13,19 @@ inherit autotools pkgconfig auto-package-utils auto-package-libs
 DEPENDS += "libuuid libdevmapper popt libgcrypt"
 
 RECIPE_FLAGS += "cryptsetup_udev"
-DEFAULT_USE_cryptsetup_udev = "0"
+DEFAULT_USE_cryptsetup_udev = False
 EXTRA_OECONF += "${EXTRA_OECONF_UDEV}"
 EXTRA_OECONF_UDEV = "--disable-udev"
 EXTRA_OECONF_UDEV:USE_cryptsetup_udev = "--enable-udev"
 
 RECIPE_FLAGS += "cryptsetup_kernel_crypto"
-DEFAULT_USE_cryptsetup_kernel_crypto = "0"
+DEFAULT_USE_cryptsetup_kernel_crypto = False
 EXTRA_OECONF += "${EXTRA_OECONF_KERNEL_CRYPTO}"
 EXTRA_OECONF_KERNEL_CRYPTO = "--disable-kernel_crypto"
 EXTRA_OECONF_KERNEL_CRYPTO:USE_cryptsetup_kernel_crypto = "--enable-kernel_crypto"
 
 RECIPE_FLAGS += "cryptsetup_selinux"
-DEFAULT_USE_cryptsetup_selinux = "0"
+DEFAULT_USE_cryptsetup_selinux = False
 EXTRA_OECONF += "${EXTRA_OECONF_SELINUX}"
 EXTRA_OECONF_SELINUX = "--disable-selinux"
 EXTRA_OECONF_SELINUX:USE_cryptsetup_selinux = "--enable-selinux"

--- a/recipes/dhcp/dhcp4.inc
+++ b/recipes/dhcp/dhcp4.inc
@@ -97,7 +97,7 @@ DEFAULT_USE_dhcp-server_sysvinit_start = "0"
 DEFAULT_USE_dhcp-server-sysvinit_stop = "0"
 
 RECIPE_FLAGS += "bind_openssl"
-DEFAULT_USE_bind_openssl = "1"
+DEFAULT_USE_bind_openssl = True
 EXTRA_OECONF += "${EXTRA_OECONF_OPENSSL}"
 EXTRA_OECONF_OPENSSL += ""
 EXTRA_OECONF_OPENSSL:USE_bind_openssl = 'LIBS="-lssl -lcrypto"'

--- a/recipes/dropbear/dropbear.inc
+++ b/recipes/dropbear/dropbear.inc
@@ -47,7 +47,7 @@ do_configure_norevdns() {
 # save several kB in binary size however will make the symmetrical
 # ciphers and hashes slower, perhaps by 50%.
 RECIPE_FLAGS += "dropbear_smallcode"
-DEFAULT_USE_dropbear_smallcode = "1"
+DEFAULT_USE_dropbear_smallcode = True
 DO_CONFIGURE_POSTFUNCS:>USE_dropbear_smallcode = " do_configure_smallcode"
 do_configure_smallcode() {
 	sed -i -e 's|/\*.*\(#define DROPBEAR_SMALL_CODE\).*$|\1|' options.h

--- a/recipes/gdb/gdb.inc
+++ b/recipes/gdb/gdb.inc
@@ -20,8 +20,8 @@ EXTRA_OECONF = "--disable-gdbtk --disable-x --disable-werror \
 	--without-lzma --without-python"
 
 RECIPE_FLAGS += "gdb_tui"
-DEFAULT_USE_gdb_tui = "1"
-DEFAULT_USE_gdb_tui:HOST_LIBC_mingw = "0"
+DEFAULT_USE_gdb_tui = True
+DEFAULT_USE_gdb_tui:HOST_LIBC_mingw = False
 GDB_DEPENDS += "${DEPENDS_TUI}"
 DEPENDS_TERMCAP = "host:libtermcap"
 DEPENDS_TERMCAP:HOST_LIBC_mingw = ""

--- a/recipes/glib/glib.inc
+++ b/recipes/glib/glib.inc
@@ -30,7 +30,7 @@ DEPENDS += "${DEPENDS_ICONV}"
 DEPENDS_ICONV:USE_glib_iconv = "libiconv"
 
 RECIPE_FLAGS += "glib_threads"
-DEFAULT_USE_glib_threads = "1"
+DEFAULT_USE_glib_threads = True
 EXTRA_OECONF += "${EXTRA_OECONF_THREADS}"
 EXTRA_OECONF_THREADS = "--disable-threads"
 EXTRA_OECONF_THREADS_TYPE = "posix"

--- a/recipes/hiawatha/hiawatha.inc
+++ b/recipes/hiawatha/hiawatha.inc
@@ -18,15 +18,15 @@ DEPENDS="libc libm libcrypt libpthread"
 RDEPENDS_${PN} += "${DEPENDS}"
 
 RECIPE_FLAGS += "hiawatha_cache hiawatha_debug hiawatha_ipv6 hiawatha_monitor hiawatha_rproxy hiawatha_ssl hiawatha_tomahawk hiawatha_toolkit hiawatha_xslt"
-DEFAULT_USE_hiawatha_cache	= "1"
-DEFAULT_USE_hiawatha_debug	= "0"
-DEFAULT_USE_hiawatha_ipv6	= "1"
-DEFAULT_USE_hiawatha_monitor	= "0"
-DEFAULT_USE_hiawatha_rproxy	= "1"
-DEFAULT_USE_hiawatha_ssl	= "1"
-DEFAULT_USE_hiawatha_tomahawk	= "0"
-DEFAULT_USE_hiawatha_toolkit	= "1"
-DEFAULT_USE_hiawatha_xslt	= "0"
+DEFAULT_USE_hiawatha_cache	= True
+DEFAULT_USE_hiawatha_debug	= False
+DEFAULT_USE_hiawatha_ipv6	= True
+DEFAULT_USE_hiawatha_monitor	= False
+DEFAULT_USE_hiawatha_rproxy	= True
+DEFAULT_USE_hiawatha_ssl	= True
+DEFAULT_USE_hiawatha_tomahawk	= False
+DEFAULT_USE_hiawatha_toolkit	= True
+DEFAULT_USE_hiawatha_xslt	= False
 
 ENABLE_cache				="-DENABLE_CACHE=off"
 ENABLE_cache:USE_hiawatha_cache		="-DENABLE_CACHE=ON"

--- a/recipes/libgcrypt/libgcrypt.inc
+++ b/recipes/libgcrypt/libgcrypt.inc
@@ -17,7 +17,7 @@ RDEPENDS_${PN} += "libgpg-error libc libcap libpthread"
 SRC_URI = "ftp://ftp.gnupg.org/gcrypt/libgcrypt/libgcrypt-${PV}.tar.gz"
 
 RECIPE_FLAGS = "libgcrypt_capabilities"
-DEFAULT_USE_libgcrypt_capabilities = "1"
+DEFAULT_USE_libgcrypt_capabilities = True
 
 EXTRA_OECONF = "--without-pth --disable-asm ${EXTRA_OECONF_CAPABILITIES}"
 EXTRA_OECONF_CAPABILITIES = "--without-capabilities"

--- a/recipes/libtiff/tiff.inc
+++ b/recipes/libtiff/tiff.inc
@@ -11,9 +11,9 @@ inherit autotools c++ auto-package-utils auto-package-libs
 AUTOCONFDIRS = "/config"
 
 RECIPE_FLAGS += "tiff_jpeg tiff_lzma tiff_zlib"
-DEFAULT_USE_tiff_jpeg = "1"
-DEFAULT_USE_tiff_lzma = "1"
-DEFAULT_USE_tiff_zlib = "1"
+DEFAULT_USE_tiff_jpeg = True
+DEFAULT_USE_tiff_lzma = True
+DEFAULT_USE_tiff_zlib = True
 
 # The configure script autodetects presence of lib{jpeg,lzma,z} and
 # enables/disables accordingly. So in principle one can control these

--- a/recipes/lighttpd/lighttpd.inc
+++ b/recipes/lighttpd/lighttpd.inc
@@ -42,7 +42,7 @@ EXTRA_OECONF_IPV6:USE_lighttpd_ipv6 = "--enable-ipv6"
 EXTRA_OECONF += "${EXTRA_OECONF_IPV6}"
 
 RECIPE_FLAGS += "lighttpd_pcre"
-DEFAULT_USE_lighttpd_pcre = "1"
+DEFAULT_USE_lighttpd_pcre = True
 EXTRA_OECONF_PCRE = "--without-pcre"
 EXTRA_OECONF_PCRE:USE_lighttpd_pcre = "--with-pcre"
 EXTRA_OECONF += "${EXTRA_OECONF_PCRE}"
@@ -53,7 +53,7 @@ DEPENDS_${PN} += "libc libcrypto libdl libm libpcre libssl libz"
 RDEPENDS_${PN} += "${DEPENDS_PCRE}"
 
 RECIPE_FLAGS += "lighttpd_zlib"
-DEFAULT_USE_lighttpd_zlib = "1"
+DEFAULT_USE_lighttpd_zlib = True
 EXTRA_OECONF_ZLIB = "--without-zlib"
 EXTRA_OECONF_ZLIB:USE_lighttpd_zlib = "--with-zlib"
 EXTRA_OECONF += "${EXTRA_OECONF_ZLIB}"
@@ -72,7 +72,7 @@ DEPENDS += "${DEPENDS_BZIP2}"
 RDEPENDS_${PN} += "${DEPENDS_BZIP2}"
 
 RECIPE_FLAGS += "lighttpd_ssl"
-DEFAULT_USE_lighttpd_ssl = "1"
+DEFAULT_USE_lighttpd_ssl = True
 EXTRA_OECONF_SSL = "--without-openssl"
 EXTRA_OECONF_SSL:USE_lighttpd_ssl = "--with-openssl=${STAGE_DIR}/${HOST_TYPE}${prefix}"
 EXTRA_OECONF += "${EXTRA_OECONF_SSL}"

--- a/recipes/mosquitto/mosquitto.inc
+++ b/recipes/mosquitto/mosquitto.inc
@@ -14,8 +14,8 @@ S = "${SRCDIR}/mosquitto-${PV}"
 inherit c++ make auto-package-libs auto-package-utils
 
 RECIPE_FLAGS = "mosquitto_uuid mosquitto_websockets"
-DEFAULT_USE_mosquitto_uuid = "1"
-DEFAULT_USE_mosquitto_websockets = "0"
+DEFAULT_USE_mosquitto_uuid = True
+DEFAULT_USE_mosquitto_websockets = False
 
 DEPENDS = "librt libssl"
 DEPENDS:>USE_mosquitto_uuid = " libuuid"

--- a/recipes/net-snmp/net-snmp.inc
+++ b/recipes/net-snmp/net-snmp.inc
@@ -13,7 +13,7 @@ EXTRA_OECONF_IPV6 = "--disable-ipv6"
 EXTRA_OECONF_IPV6:USE_netsnmp_ipv6 = "--enable-ipv6"
 EXTRA_OECONF += "${EXTRA_OECONF_IPV6}"
 
-DEFAULT_USE_netsnmp_mibs = "1"
+DEFAULT_USE_netsnmp_mibs = True
 RECIPE_FLAGS += "netsnmp_mibs"
 EXTRA_OECONF_MIBS = "--with-out-mib-modules=examples/ucdDemoPublic --disable-mibs --disable-mib-loading"
 EXTRA_OECONF_MIBS:USE_netsnmp_mibs = ""

--- a/recipes/netperf/netperf.inc
+++ b/recipes/netperf/netperf.inc
@@ -23,7 +23,7 @@ RECIPE_FLAGS += "netperf_ipv6"
 CFLAGS:>USE_netperf_ipv6 = " -DDO_IPV6"
 
 inherit largefile
-DEFAULT_USE_largefile = "1"
+DEFAULT_USE_largefile = True
 
 RECIPE_FLAGS += "netperf_histogram"
 EXTRA_OECONF:>USE_netperf_histogram = " --enable-histogram"

--- a/recipes/ntp/ntp.inc
+++ b/recipes/ntp/ntp.inc
@@ -54,7 +54,7 @@ do_configure_ntpd_init() {
 }
 
 RECIPE_FLAGS += "ntpdate_ifup"
-DEFAULT_USE_ntpdate_ifup = "1"
+DEFAULT_USE_ntpdate_ifup = True
 DO_INSTALL_NTPDATE = ""
 DO_INSTALL_NTPDATE:USE_ntpdate_ifup = "do_install_ntpdate"
 do_install[postfuncs] += "${DO_INSTALL_NTPDATE}"

--- a/recipes/rsyslog/rsyslog_8.6.0.oe
+++ b/recipes/rsyslog/rsyslog_8.6.0.oe
@@ -13,4 +13,4 @@ EXTRA_OECONF += "${EXTRA_OECONF_LIBDBI}"
 DEPENDS:>USE_enable_libdbi += " libdbi libdbi-dev"
 DEPENDS_${PN}:>USE_enable_libdbi += " libdbi"
 RDEPENDS_${PN}:>USE_enable_libdbi += " libdbi libdbd-sqlite3"
-DEFAULT_USE_enable_libdbi = "0"
+DEFAULT_USE_enable_libdbi = False

--- a/recipes/splashutils/splashutils.inc
+++ b/recipes/splashutils/splashutils.inc
@@ -25,7 +25,7 @@ EXTRA_OECONF += "--without-lpng-src"
 EXTRA_OECONF += "--without-zlib-src"
 
 RECIPE_FLAGS += "splashutils_png"
-DEFAULT_USE_splashutils_png = "1"
+DEFAULT_USE_splashutils_png = True
 DEPENDS += "${DEPENDS_PNG}"
 DEPENDS_PNG = ""
 DEPENDS_PNG:USE_splashutils_png = "libpng12"

--- a/recipes/sqlite/sqlite3.inc
+++ b/recipes/sqlite/sqlite3.inc
@@ -18,14 +18,14 @@ EXTRA_OECONF += "${EXTRA_OECONF_THREADSAFE}"
 DEPENDS_PTHREAD = "libpthread"
 DEPENDS_PTHREAD:HOST_LIBC_mingw = ""
 DEPENDS:>USE_sqlite3_threadsafe = " ${DEPENDS_PTHREAD}"
-DEFAULT_USE_sqlite3_threadsafe = "1"
+DEFAULT_USE_sqlite3_threadsafe = True
 
 RECIPE_FLAGS += "sqlite3_readline"
 EXTRA_OECONF_READLINE = "--disable-readline"
 EXTRA_OECONF_READLINE:USE_sqlite3_readline = "--enable-readline"
 EXTRA_OECONF += "${EXTRA_OECONF_READLINE}"
 DEPENDS:>USE_sqlite3_readline = " libreadline"
-DEFAULT_USE_sqlite3_readline = "1"
+DEFAULT_USE_sqlite3_readline = True
 
 RECIPE_FLAGS += "sqlite3_extensions"
 EXTRA_OECONF_EXTENSIONS = "--disable-dynamic-extensions"

--- a/recipes/wpa-supplicant/wpa-supplicant.inc
+++ b/recipes/wpa-supplicant/wpa-supplicant.inc
@@ -37,22 +37,22 @@ RECIPE_FLAGS += "wpa_supplicant_wps"
 WPA_SUPPLICANT_FLAGS:>USE_wpa_supplicant_wps += " CONFIG_WPS CONFIG_WPS2"
 
 RECIPE_FLAGS += "wpa_supplicant_libnl"
-DEFAULT_USE_wpa_supplicant_libnl = "1"
+DEFAULT_USE_wpa_supplicant_libnl = True
 WPA_SUPPLICANT_FLAGS:>USE_wpa_supplicant_libnl += " CONFIG_LIBNL32"
 
 RECIPE_FLAGS += "wpa_supplicant_gnutls"
-DEFAULT_USE_wpa_supplicant_gnutls = "1"
+DEFAULT_USE_wpa_supplicant_gnutls = True
 WPA_SUPPLICANT_FLAGS:>USE_wpa_supplicant_gnutls += " CONFIG_TLS=gnutls"
 CRYPTO:>USE_wpa_supplicant_gnutls = " libgnutls libgcrypt"
 CRYPTO = " libssl libcrypto"
 
 RECIPE_FLAGS += "wpa_supplicant_dbus"
-DEFAULT_USE_wpa_supplicant_dbus = "1"
+DEFAULT_USE_wpa_supplicant_dbus = True
 WPA_SUPPLICANT_FLAGS:>USE_wpa_supplicant_dbus += " CONFIG_CTRL_IFACE_DBUS CONFIG_CTRL_IFACE_DBUS_NEW"
 DEPENDS:>USE_wpa_supplicant_dbus += " libdbus-1"
 
 RECIPE_FLAGS += "wpa_supplicant_ap"
-DEFAULT_USE_wpa_supplicant_ap = "1"
+DEFAULT_USE_wpa_supplicant_ap = True
 WPA_SUPPLICANT_FLAGS:>USE_wpa_supplicant_ap += " CONFIG_AP"
 
 do_configure () {


### PR DESCRIPTION
The OE-lite lexer recognizes True and False as tokens, and currently ends up storing the strings "1" and "0", respectively. This means that these patches are all semantic noops (they also do not change metadata hashes). However, they serve to highlight which USE flags are actually meant as boolean on/off switches, as opposed to those whose string value is used. 