### PR TITLE
busybox-configure.inc: remove use of broken [precondition] flag

### DIFF
--- a/recipes/busybox/busybox-configure.inc
+++ b/recipes/busybox/busybox-configure.inc
@@ -153,8 +153,10 @@ DEFAULT_USE_busybox_syslogd_ipc = False
 DEFAULT_USE_busybox_syslogd_ipc_bufsize = "16"
 # USE flag: enable remote syslogd support
 DEFAULT_USE_busybox_syslogd_remote = False
-# USE flag: syslogd remote host (should be set to -R and optionally -L args)
-DEFAULT_USE_busybox_syslogd_remote_host = "0"
+# USE flag: syslogd remote host (should be set to -R and optionally -L
+# args). If enabling busybox_syslogd_remote, you must also set this to
+# a sensible value.
+DEFAULT_USE_busybox_syslogd_remote_host = "example.net -L"
 # USE flag: enable syslogd log rotation support
 DEFAULT_USE_busybox_syslogd_rotate = False
 # USE flag: syslogd log rotation size (in kByte)
@@ -182,7 +184,6 @@ do_configure_busybox_syslogd_ipc () {
         .config
 }
 DO_CONFIGURE_PREFUNCS:>USE_busybox_syslogd_remote = " do_configure_busybox_syslogd_remote"
-do_configure_busybox_syslogd_remote[precondition] = "${USE_busybox_syslogd_remote}"
 do_configure_busybox_syslogd_remote () {
         sed -i -e 's/^# \(CONFIG_FEATURE_REMOTE_LOG\) is not set/\1=y/' \
         .config


### PR DESCRIPTION
The [precondition] flag was introduced in meta/core commit b275b0c33a8,
but has never worked the way it was supposed to - instead, any variable
with this flag gets unconditionally deleted(!). So regardless of the
value of USE_busybox_syslogd_remote, the function
do_configure_busybox_syslogd_remote would not exist, in which case
OE-lite happily substitutes a succesful no-op function.

Moreover, the right-hand side of this [precondition] assignment is wrong
- we already append the prefunc conditional on
USE_busybox_syslogd_remote, so this was supposed to further check that
USE_busybox_syslogd_remote_host was set to a non-empty string.

Effectively, no-one has ever been able to use the busybox_syslogd_remote
feature by setting USE_busybox_syslogd_remote. But the [precondition]
line has served one purpose: preventing the hash computation from
failing with an "Cannot expand variable
${USE_busybox_syslogd_remote_host}".

Rather than letting that variable have a non-sensical value [1] which,
with the current USE flag handling, causes it not to be defined at all,
let's just give it a default value showing how it's supposed to be
set. I assume that somebody that actually enables remote logging would
also test it.

[1] "0" does not match the pseudo-regexp "<valid-ip-or-domain>(:<port>)?( -L)?".