### PR TITLE
bind: USE flag control of libz dependency

### DIFF
--- a/recipes/bind/bind.inc
+++ b/recipes/bind/bind.inc
@@ -28,6 +28,16 @@ EXTRA_OECONF = "\
     --with-export-libdir=${libdir} \
 "
 
+RECIPE_FLAGS += "bind_zlib"
+EXTRA_OECONF_ZLIB = "--without-zlib"
+EXTRA_OECONF_ZLIB:USE_bind_zlib = "--with-zlib"
+EXTRA_OECONF += "${EXTRA_OECONF_ZLIB}"
+DEPENDS:>USE_bind_zlib = " libz"
+DEPENDS_${PN}:>USE_bind_zlib = " libz"
+RDEPENDS_${PN}:>USE_bind_zlib = " libz"
+DEPENDS_${PN}-utils:>USE_bind_zlib = " libz"
+RDEPENDS_${PN}-utils:>USE_bind_zlib = " libz"
+
 RECIPE_FLAGS += "bind_sysvinit_start bind_sysvinit_stop"
 SYSVINI_SCRIPT_bind = "bind"
 DEFAULT_USE_bind_sysvinit_start= "20"


### PR DESCRIPTION
Without this, I see:

    checking for json library... no
    checking for zlib library... yes
    checking for library containing deflate... no
    configure: error: found zlib include but not library.
    Error: Command failed: 'LC_ALL=C ..../bind-9.11.0-P1/tmp/do_configure.20161111151724.run': 1

Signed-off-by: Esben Haabendal <esben@haabendal.dk>