### PR TITLE
monit: change away from bitbucket URL

### DIFF
--- a/recipes/monit/monit.inc
+++ b/recipes/monit/monit.inc
@@ -3,6 +3,7 @@ inherit sysvinit
 COMPATIBLE_HOST_ARCHS = ".*linux"
 
 SRC_URI = " \
+	https://mmonit.com/monit/dist/monit-${PV}.tar.gz \
 	file://monit \
 	"
 

--- a/recipes/monit/monit_5.20.0.oe
+++ b/recipes/monit/monit_5.20.0.oe
@@ -2,7 +2,5 @@ require monit.inc
 
 inherit autotools
 
-SRC_URI += "https://bitbucket.org/tildeslash/monit/downloads/monit-${PV}.tar.gz"
-
 DEPENDS += "libz libm"
 RDEPENDS_${PN} += "libz libm"


### PR DESCRIPTION
Apparently, bitbucket imposes some rather harsh download rate
limits (5000 downloads per hour). The buildbot occasionally hits that,
causing entirely unrelated builds to fail, so let's avoid bitbucket URLs
when we can. In this case the monit website itself also hosts the
tar-balls.

While at it, move the SRC_URI definition to the .inc files as it's
normally done.