### PR TITLE
boost.inc: remove stray do_fetch prefunc

### DIFF
--- a/recipes/boost/boost.inc
+++ b/recipes/boost/boost.inc
@@ -162,7 +162,6 @@ LIBRARY_VERSION = "1"
 PACKAGES += "${PN}-full ${PN}-full-dev"
 RDEPENDS_${PN}-full += "${LIBS_AUTO_RPACKAGES}"
 addhook add_deps to post_recipe_parse after auto_package_libs before blacklist
-do_fetch[prefuncs] += "add_deps"
 def add_deps(d):
     pn = (d.get('PN') or '')
     rdeps = (d.get('LIBS_AUTO_RPACKAGES') or '').split( )


### PR DESCRIPTION
First of all, the addhook statement has the side-effect of setting the
emit flag to "" for the function in question, so add_deps is not
available when do_fetch runs, so this does nothing. (When asked to run a
non-existing function, OE-lite substitutes an always-successful noop
function.) I also fail to see what setting an RDEPENDS_ variable has to
do with do_fetch.