### PR TITLE
monit: re-add fix-rebuild.patch and disable parallel make

### DIFF
--- a/recipes/monit/files/fix-rebuild.patch
+++ b/recipes/monit/files/fix-rebuild.patch
@@ -1,3 +1,14 @@
+Forcing do_configure to run again consistently fails without this
+patch applied. That is, doing
+
+  oe bake monit -y # from clean state
+  rm tmp/stamp/machine/arm-926ejs-linux-gnueabi/monit-5.20.0/do_configure
+  oe bake monit -y # this fails
+
+Source: OE-lite
+Upstream-status: not submitted
+
+
 --- a/libmonit/test/Makefile.am~	2012-05-06 11:40:45.000000000 +0200
 +++ b/libmonit/test/Makefile.am	2013-05-06 10:58:41.502912238 +0200
 @@ -31,9 +31,6 @@

--- a/recipes/monit/monit.inc
+++ b/recipes/monit/monit.inc
@@ -5,9 +5,15 @@ COMPATIBLE_HOST_ARCHS = ".*linux"
 SRC_URI = " \
 	https://mmonit.com/monit/dist/monit-${PV}.tar.gz \
 	file://monit \
+	file://fix-rebuild.patch \
 	"
 
 LICENSE = "AGPL-3.0"
+
+# Upstream explicitly says "Do not run make in parallel" in response
+# to a bug where the reporter used -j2.
+# <https://bitbucket.org/tildeslash/monit/issues/238/make-failed>
+PARALLEL_MAKE = ""
 
 DEPENDS = "libssl libpthread libcrypto libdl libcrypt"
 DEPENDS_${PN} = "libssl libpthread libcrypto libc libcrypt"


### PR DESCRIPTION
I can consistently reproduce the error we see on the
buildbot (Makefile.in missing) by first
successfully building monit from a clean slate, then removing
tmp/stamp/machine/arm-926ejs-linux-gnueabi/monit-5.20.0/do_configure and
trying to build it again. Adding the fix-rebuild.patch makes that
problem go away.

I then tried to stress it a little by removing random stamp files, and
it didn't take long for do_compile to fail; most often with a "undefined
reference to yyerror", but also with something like

  mv: cannot stat 'src/.y.tab.c': No such file or directory

These, and the inconsistent occurrence, strongly indicate a parallel
make problem, and sure enough, upstream actually says "Do not run make
in parallel"
<https://bitbucket.org/tildeslash/monit/issues/238/make-failed>.

Disabling parallel make itself is not enough; the above reproducer still
works if I omit the fix-rebuild.patch.