### PR TITLE
cppunit: explicitly disable doxygen and dot

### DIFF
--- a/recipes/cppunit/cppunit.inc
+++ b/recipes/cppunit/cppunit.inc
@@ -25,3 +25,5 @@ RDEPENDS_${PN} = "libdl libm libc libgcc-s libstdc++"
 AUTO_PACKAGE_UTILS = "cppunit-config DllPlugInTester"
 AUTO_PACKAGE_UTILS_DEPENDS ="${PN}"
 AUTO_PACKAGE_UTILS_RDEPENDS = "${PN}"
+
+EXTRA_OECONF += "--disable-doxygen --disable-dot"


### PR DESCRIPTION
The --enable-{doxygen,dot} configure options default to 'auto', which
at least on my build host causes them to be picked up, which then
causes do_split to fail due to lots of files in
/usr/share/cppunit.