### PR TITLE
opencv: fix mingw build

### DIFF
--- a/recipes/opencv/opencv.inc
+++ b/recipes/opencv/opencv.inc
@@ -7,7 +7,7 @@ LICENSE = "BSD-3-Clause"
 
 ARM_INSTRUCTION_SET = "arm"
 
-DEPENDS_LIBC = "librt libc"
+DEPENDS_LIBC = "librt libc libdl"
 DEPENDS_LIBC:HOST_LIBC_mingw = ""
 DEPENDS += "${DEPENDS_LIBC} libbz2 libz libglib"
 SRC_URI = "https://github.com/Itseez/${PN}/archive/${PV}.tar.gz \
@@ -43,7 +43,7 @@ FILES_${PN}-dbg += "${libdir}/.debug"
 FILES_${PN}-dev = "${libdir}/*.a ${includedir} ${libdir}/pkgconfig"
 FILES_${PN}-doc = "${datadir}/OpenCV/doc"
 
-CDEPS = "libdl libgcc libm libpng16 libpthread ${DEPENDS_LIBC} libstdc++"
+CDEPS = "libgcc libm libpng16 libpthread ${DEPENDS_LIBC} libstdc++"
 DEPENDS_${PN} += "${CDEPS} libjpeg libz"
 RDEPENDS_${PN} += "${CDEPS} libjpeg libz"
 DEPENDS_${PN}-apps += "${CDEPS}"


### PR DESCRIPTION
libdl is only listed as a package dependency for the package opencv, not
as a build dependency. Doing "oe bake opencv" works fine, but trying to
build anything that DEPENDS on opencv gives

FATAL: No provider for machine:libdl (needed by machine:opencv)

in the mingw build. Move the libdl dependency to the DEPENDS_LIBC
variable which is cleared for the mingw build. While maybe not the
correct/best fix, both native:opencv and machine:opencv pass packageqa
for both mingw and arm-926ejs.