### PR TITLE
valgrind: re-add arm-cortex-support.patch

### DIFF
--- a/recipes/valgrind/files/arm-cortex-support.patch
+++ b/recipes/valgrind/files/arm-cortex-support.patch
@@ -1,0 +1,29 @@
+Valgrind's configure script checks for ${host_cpu} starting with
+armv7, but we call it just arm. Since Cortex A chips are (at least)
+ARMv7, make the configure script recognize arm-cortexa*.
+
+Origin: OE-lite (first introduced in 5b66593c)
+Upstream-status: Not attempted
+
+--- valgrind-3.12.0/configure.ac.orig	2017-01-11 08:28:48.965259010 +0000
++++ valgrind-3.12.0/configure.ac	2017-01-11 08:37:18.151478924 +0000
+@@ -239,6 +239,19 @@
+ 	ARCH_MAX="arm"
+ 	;;
+ 
++     arm)
++	case "${host_vendor}" in
++	    cortexa*)
++		AC_MSG_RESULT([ok (${host_cpu}-${host_vendor})])
++		ARCH_MAX="arm"
++		;;
++	    *)
++		AC_MSG_RESULT([no (${host_cpu}-${host_vendor})])
++		AC_MSG_ERROR([Unsupported host architecture. Sorry])
++		;;
++	esac
++	;;
++
+      aarch64*)
+        AC_MSG_RESULT([ok (${host_cpu})])
+        ARCH_MAX="arm64"

--- a/recipes/valgrind/valgrind.inc
+++ b/recipes/valgrind/valgrind.inc
@@ -15,6 +15,7 @@ RDEPENDS_${PN}-valgrind-listener = "libc"
 DEPENDS_${PN} += "libc libpthread"
 
 SRC_URI = "http://www.valgrind.org/downloads/valgrind-${PV}.tar.bz2"
+SRC_URI:>TARGET_CPU_arm += " file://arm-cortex-support.patch"
 
 EXTRA_OECONF = "--enable-tls"
 


### PR DESCRIPTION
The patch to make valgrind's configure system recognize arm-cortexa* was
omitted from the upgrade to 3.12, but it is still needed. Add it back in
a slightly modified form

- only patch the .ac file since we now do autoreconf anyway
- add a patch header
- put it into non-version specific subdirectory, since we're likely
  going to need this forever
- only apply it when the target cpu is indeed arm