### PR TITLE
util-linux: ncurses fixups

### DIFF
--- a/recipes/util-linux/util-linux.inc
+++ b/recipes/util-linux/util-linux.inc
@@ -6,7 +6,7 @@ RECIPE_TYPES = "machine native sdk"
 
 COMPATIBLE_HOST_ARCHS = ".*linux"
 
-inherit autotools autotools-autoreconf gettext
+inherit autotools autotools-autoreconf gettext pkgconfig
 
 require conf/fetch/kernelorg.conf
 MA = "${@d.get('PV').split('.')[0]}"
@@ -23,9 +23,9 @@ EXTRA_OECONF = "\
 "
 
 RECIPE_FLAGS += "ncurses"
-EXTRA_OECONF += "${EXTRA_OECONF_NCURSES}"
-EXTRA_OECONF_NCURSES = " --without-ncurses --without-ncursesw"
-EXTRA_OECONF_NCURSES:USE_ncurses = " --with-ncurses"
+EXTRA_OECONF += " --without-ncursesw ${EXTRA_OECONF_NCURSES}"
+EXTRA_OECONF_NCURSES = " --without-ncurses"
+EXTRA_OECONF_NCURSES:USE_ncurses = " --with-ncurses --disable-widechar"
 DEPENDS:>USE_ncurses = " libncurses"
 # FIXME: add ncursesw USE flag support
 


### PR DESCRIPTION
When trying to compile with USE_ncurses set, I hit lots of weird
errors. I think part of the problem is that --with-ncursesw is 'auto' by
default, so it is not enough to disable that in the !USE_ncurses case,
it very much also has to be explicitly disabled when we want to use the
--with-ncurses option. Otherwise, the configure script tries
to run ncursesw-config, which it happened to pick up from the host, and
then it obviously fails when it can't link with libncursesw.

But we also have to explicitly disable widechar support to convince the
configure script that --with-ncurses is ok, otherwise one gets a
non-helpful

  wide-char support enabled, but non-wide ncurses selects

For me (with MACHINE_CPU = "arm-926ejs"), the end result passes
packageqa with and without USE_ncurses set.