### PR TITLE
Revert "gdb: remove version 7.10.1"

### DIFF
--- a/recipes/gdb/gdb_7.10.1.oe
+++ b/recipes/gdb/gdb_7.10.1.oe
@@ -1,0 +1,1 @@
+require gdb.inc

--- a/recipes/gdb/gdb_7.10.1.oe.sig
+++ b/recipes/gdb/gdb_7.10.1.oe.sig
@@ -1,0 +1,1 @@
+f5a47daa50df3b79a73c7c717363ee3a7e040e07  gdb-7.10.1.tar.gz

--- a/recipes/gdb/gdb_7.11.oe
+++ b/recipes/gdb/gdb_7.11.oe
@@ -18,3 +18,5 @@ MUSL_MAKE:HOST_LIBC_musl = "gt_cv_func_gnugettext1_libc=yes \
                             gt_cv_func_gnugettext2_libc=yes \
                             "
 CFLAGS:>HOST_LIBC_musl += " -Drpl_gettimeofday=gettimeofday"
+
+PRIORITY = "-1"


### PR DESCRIPTION
This reverts commit cc3ad55bbb6e3161b54880aab38924536cb6c8e8, and sets
the priority for gdb 7.11 to -1 to make OE-lite pick up 7.10.1 by
default (unless one explicitly depends on 7.11).

With 7.11, our internal fulltest fails with

   thread.c:982: internal-error: is_thread_state: Assertion `tp' failed.
   A problem internal to GDB has been detected,
   further debugging may prove unreliable.

I don't see any of the patches we apply on top of 7.11 touching that
file, so I don't know if one of those are to blame, or if it's simply
7.11 which is broken - google only turns up with ancient hits, much
older than 7.11. Whatever the cause, reverting to 7.10.1 fixes the
issue.

Signed-off-by: Rasmus Villemoes <rasmus.villemoes@prevas.dk>