### PR TITLE
libwebsockets: update SRC_URI

### DIFF
--- a/recipes/libwebsockets/libwebsockets.inc
+++ b/recipes/libwebsockets/libwebsockets.inc
@@ -5,7 +5,7 @@ HOMEPAGE = "https://libwebsockets.org/"
 COMPATIBLE_HOST_ARCHS = ".*linux"
 RECIPE_TYPES = "machine"
 
-SRC_URI = "git://git.libwebsockets.org/libwebsockets.git;protocol=git;tag=v${PV}"
+SRC_URI = "git://github.com/warmcat/libwebsockets;tag=v${PV}"
 S = "${SRCDIR}/${PN}"
 
 inherit cmake library auto-package-utils

--- a/recipes/libwebsockets/libwebsockets_2.1.0.oe.sig
+++ b/recipes/libwebsockets/libwebsockets_2.1.0.oe.sig
@@ -1,1 +1,1 @@
-73557509bd15f95a1ad081a6f4fab48ff7743215  git://git.libwebsockets.org/libwebsockets.git;tag=v2.1.0
+73557509bd15f95a1ad081a6f4fab48ff7743215  git://github.com/warmcat/libwebsockets;tag=v2.1.0


### PR DESCRIPTION
Lots of buildbot builds are failing since the libwebsockets git
repository is no longer accessible via this URL. Use github instead.