### PR TITLE
busybox: Add s6-rc integration of hwclock

### DIFF
--- a/recipes/busybox/busybox.inc
+++ b/recipes/busybox/busybox.inc
@@ -75,6 +75,11 @@ do_compile_binfmt_flat_fixup() {
 
 require busybox-install.inc
 
+inherit s6rc
+SRC_URI:>USE_s6rc = " file://rtc.up file://rtc.down"
+S6RC_ONESHOT_SERVICES:>USE_busybox_hwclock = " rtc"
+RECIPE_FLAGS += "rtc_s6rc_dependencies"
+
 PACKAGES:<USE_busybox_udhcpd = "${PN}-udhcpd-config "
 PROVIDES_${PN}-udhcpd-config = " udhcpd-config"
 FILES_${PN}-udhcpd-config = "${sysconfdir}/udhcpd.conf "

--- a/recipes/busybox/busybox_1.25.1.oe
+++ b/recipes/busybox/busybox_1.25.1.oe
@@ -3,5 +3,4 @@ require busybox.inc
 SRC_URI += "file://dhclient-options.patch"
 SRC_URI += "file://mdev-create-devices-from-sys-dev.patch"
 
-RECIPE_FLAGS += "s6rc"
 SRC_URI:>USE_s6rc += " file://ifupdown-s6-init.patch"

--- a/recipes/busybox/files/rtc.down
+++ b/recipes/busybox/files/rtc.down
@@ -1,0 +1,11 @@
+#!/bin/execlineb -P
+s6-envdir -I /etc/hwclock
+import -D 1 UTC
+backtick -n -i utc_arg {
+  ifelse { test ${UTC} = 1 }
+  { s6-echo -- "-u" }
+  s6-echo -- "-l"
+}
+import utc_arg
+import -D /dev/rtc DEVICE
+hwclock -w ${utc_arg} -f ${DEVICE}

--- a/recipes/busybox/files/rtc.up
+++ b/recipes/busybox/files/rtc.up
@@ -1,0 +1,11 @@
+#!/bin/execlineb -P
+s6-envdir -I /etc/hwclock
+import -D 1 UTC
+backtick -n -i utc_arg {
+  ifelse { test ${UTC} = 1 }
+  { s6-echo -- "-u" }
+  s6-echo -- "-l"
+}
+import utc_arg
+import -D /dev/rtc DEVICE
+hwclock -s ${utc_arg} -f ${DEVICE}


### PR DESCRIPTION
This adds an s6-rc service called rtc, which reads hardware clock (RTC)
on start, and writes it on stop.  It can be handy as startup and shutdown
service.

If /etc/hwclock/UTC file exists and does contain something else than the
string "1", the time hwclock is assumed to contain local time. Otherwise,
it is assumed to contain UTC time.

If /etc/hwclock/DEVICE file exists, it specifies the RTC device to use.
Otherwise, /dev/rtc is used.