### PR TITLE
netbase: Fix creation of dummy udhcpc@ service

### DIFF
--- a/recipes/netbase/netbase/net-udhcpc.hook
+++ b/recipes/netbase/netbase/net-udhcpc.hook
@@ -5,6 +5,6 @@ backtick -n hooksdir { dirname $0 }
 import -u hooksdir
 define basename udhcpc@
 define templatedir ${hooksdir}/${basename}.d
-forbacktickx iface { dhcp-interfaces }
+forbacktickx -C -n iface { dhcp-interfaces }
 import -u iface
 cp -r ${templatedir}/ ${1}/${basename}${iface}/


### PR DESCRIPTION
This fixes a bug causing an empty `udhcpc@` service to be created when
dhcp-interfaces returns no interfaces.

Signed-off-by: Esben Haabendal <esben@haabendal.dk>