### PR TITLE
lighttpd: Package entire /www with config files that define it

### DIFF
--- a/recipes/lighttpd/lighttpd.inc
+++ b/recipes/lighttpd/lighttpd.inc
@@ -108,9 +108,8 @@ do_install_lighttpd_extra() {
 PACKAGES =+ "${PN}-config"
 FILES_${PN} += "${sysconfdir}"
 FILES_${PN} += "${libdir}/mod_*"
-FILES_${PN} += "/www"
 FILES_${PN}-config = "${sysconfdir}/lighttpd.conf"
-FILES_${PN}-config += "/www/pages/"
+FILES_${PN}-config += "/www"
 RDEPENDS_${PN} += "${PN}-config"
 
 RDEPENDS_${PN} += "libc libgcc libdl libm"


### PR DESCRIPTION
All direct references to the /www directory is specified by the lighttpd.conf
file, so when using a custom lighttpd-config, it is very likely that you would
not want to have the /www included.

Signed-off-by: Esben Haabendal <esben@haabendal.dk>