### PR TITLE
s6-init: Do not log kernel debug messages

### DIFF
--- a/recipes/s6-init/s6-init/klogd-log.run
+++ b/recipes/s6-init/s6-init/klogd-log.run
@@ -4,4 +4,4 @@ if { if -t -n { test -e /var/log/kernel }
   install -d -m 755 -o nobody -g nogroup /var/log/kernel }
 s6-setuidgid nobody
 exec -c
-s6-log t s1000000 n20 /var/log/kernel
+s6-log t s1000000 n20 -^kern.debug /var/log/kernel


### PR DESCRIPTION
They are generally just noisy, and will thus clutter your logs and fill up
your disks.

Signed-off-by: Esben Haabendal <esben@haabendal.dk>