### PR TITLE
s6-init: Add alternative init-sysctl.up script using sysctl command

### DIFF
--- a/recipes/s6-init/s6-init.oe
+++ b/recipes/s6-init/s6-init.oe
@@ -78,6 +78,10 @@ DEFAULT_USE_init_sysctl_s6rc_dependencies = "mount-proc"
 RECIPE_FLAGS += "init_sysctl_s6rc_timeout_up"
 SRC_URI += "file://init-sysctl.up"
 
+# Flag to use the real sysctl command for init-sysctl service
+RECIPE_FLAGS += "s6_init_real_sysctl"
+RDEPENDS_${PN}:>USE_s6_init_real_sysctl = " util/sysctl"
+
 S6RC_ONESHOT_SERVICES += "init-urandom"
 RECIPE_FLAGS += "init_urandom_s6rc_dependencies"
 RECIPE_FLAGS += "init_urandom_s6rc_timeout_up"

--- a/recipes/s6-init/s6-init/USE_s6_init_real_sysctl/init-sysctl.up
+++ b/recipes/s6-init/s6-init/USE_s6_init_real_sysctl/init-sysctl.up
@@ -1,0 +1,2 @@
+if -t { test -f /etc/sysctl.conf }
+sysctl -q -p /etc/sysctl.conf


### PR DESCRIPTION
If you are okay with including sysctl command in your filesystem, you
can just as well use it instead of the execline alternative.

Signed-off-by: Esben Haabendal <esben@haabendal.dk>