### PR TITLE
stress-ng: new recipe

### DIFF
--- a/recipes/stress-ng/files/0002-Add-autodetection-for-64-byte-alignment-of-functions.patch
+++ b/recipes/stress-ng/files/0002-Add-autodetection-for-64-byte-alignment-of-functions.patch
@@ -1,0 +1,191 @@
+From 9c7d1c449945538d35874cffe713e8d259e75beb Mon Sep 17 00:00:00 2001
+From: Colin Ian King <colin.king@canonical.com>
+Date: Tue, 28 Mar 2017 23:19:59 +0100
+Subject: [PATCH 2/4] Add autodetection for 64 byte alignment of functions (LP:
+ #1676834)
+
+Rather than trying to poorly guess of 64 byte alignment is available
+we should autodetect this at config build time. Add a helper to test
+build with forced 64 byte alignment and define DHAVE_ALIGNED_64 if
+it is available.
+
+Signed-off-by: Colin Ian King <colin.king@canonical.com>
+---
+ Makefile          | 28 ++++++++++++++++++++++++++--
+ stress-icache.c   | 13 ++++---------
+ stress-ng.h       |  2 +-
+ test-aligned-64.c | 41 +++++++++++++++++++++++++++++++++++++++++
+ 4 files changed, 72 insertions(+), 12 deletions(-)
+ create mode 100644 test-aligned-64.c
+
+diff --git a/Makefile b/Makefile
+index db668d4..cb05dea 100644
+--- a/Makefile
++++ b/Makefile
+@@ -262,7 +262,8 @@ LIB_SCTP = -lsctp
+ HAVE_NOT=HAVE_APPARMOR=0 HAVE_KEYUTILS_H=0 HAVE_XATTR_H=0 HAVE_LIB_BSD=0 \
+ 	 HAVE_LIB_Z=0 HAVE_LIB_CRYPT=0 HAVE_LIB_RT=0 HAVE_LIB_PTHREAD=0 \
+ 	 HAVE_FLOAT_DECIMAL=0 HAVE_SECCOMP_H=0 HAVE_LIB_AIO=0 HAVE_SYS_CAP_H=0 \
+-	 HAVE_VECMATH=0 HAVE_ATOMIC=0 HAVE_LIB_SCTP=0 HAVE_ASM_NOP=0
++	 HAVE_VECMATH=0 HAVE_ATOMIC=0 HAVE_LIB_SCTP=0 HAVE_ASM_NOP=0 \
++	 HAVE_ALIGNED_64=0
+ 
+ #
+ #  Load in current config; use 'make clean' to clear this
+@@ -432,6 +433,14 @@ $(info autoconfig: using nop assembler instruction)
+ endif
+ endif
+ 
++ifndef $(HAVE_ALIGNED_64)
++HAVE_ALIGNED_64 = $(shell $(MAKE) --no-print-directory $(HAVE_NOT) have_aligned_64)
++ifeq ($(HAVE_ALIGNED_64),1)
++	CONFIG_CFLAGS += -DHAVE_ALIGNED_64
++$(info autoconfig: using 64 byte alignment attribute)
++endif
++endif
++
+ endif
+ endif
+ 
+@@ -692,6 +701,20 @@ have_atomic: stress-atomic.c
+ 	@rm -rf stress-atomic-test
+ 
+ #
++#  check if we can build functions aligned to 64 byte boundaries
++#
++.PHONEY: have_aligned_64
++have_aligned_64: test-aligned-64.c
++	@$(CC) $(CPPFLAGS) test-aligned-64.c -o test-aligned-64 2> /dev/null || true
++	@if [ -f test-aligned-64 ]; then \
++		echo 1 ;\
++	else \
++		echo 0 ;\
++	fi
++	@rm -rf test-aligned-64
++
++
++#
+ #  extract the PER_* personality enums
+ #
+ personality.h:
+@@ -738,7 +761,8 @@ dist:
+ 		test-apparmor.c test-libbsd.c test-libz.c \
+ 		test-libcrypt.c test-librt.c test-libpthread.c \
+ 		test-libaio.c test-cap.c test-libsctp.c \
+-		test-asm-nop.c usr.bin.pulseaudio.eg perf-event.c \
++		test-asm-nop.c test-aligned-64.c \
++		usr.bin.pulseaudio.eg perf-event.c \
+ 		snapcraft smatchify.sh config TODO stress-ng-$(VERSION)
+ 	tar -zcf stress-ng-$(VERSION).tar.gz stress-ng-$(VERSION)
+ 	rm -rf stress-ng-$(VERSION)
+diff --git a/stress-icache.c b/stress-icache.c
+index 7ce02e1..599a381 100644
+--- a/stress-icache.c
++++ b/stress-icache.c
+@@ -38,11 +38,6 @@
+ #define ALIGNED(a) __attribute__((aligned(a)))
+ #endif
+ 
+-/* older ARMEL GCC does not support 64K alignment */
+-#if (defined(__GNUC__) && NEED_GNUC(5,4,0)) || !defined(__ARMEL__)
+-#define ALIGNED_64K_SUPPORTED
+-#endif
+-
+ /*
+  *  STRESS_ICACHE_FUNC()
+  *	generates a simple function that is page aligned in its own
+@@ -159,13 +154,13 @@ static inline int icache_madvise(const args_t *args, void *addr, size_t size)
+ 	return 0;
+ }
+ 
+-#if defined(ALIGNED_64K_SUPPORTED)
++#if defined(HAVE_ALIGNED_64)
+ STRESS_ICACHE_FUNC(stress_icache_func_64K, SIZE_64K)
+ #endif
+ STRESS_ICACHE_FUNC(stress_icache_func_16K, SIZE_16K)
+ STRESS_ICACHE_FUNC(stress_icache_func_4K, SIZE_4K)
+ 
+-#if defined(ALIGNED_64K_SUPPORTED)
++#if defined(HAVE_ALIGNED_64)
+ STRESS_ICACHE(stress_icache_64K, SIZE_64K, stress_icache_func_64K)
+ #endif
+ STRESS_ICACHE(stress_icache_16K, SIZE_16K, stress_icache_func_16K)
+@@ -189,13 +184,13 @@ int stress_icache(const args_t *args)
+ 	case SIZE_16K:
+ 		ret = stress_icache_16K(args);
+ 		break;
+-#if defined(ALIGNED_64K_SUPPORTED)
++#if defined(HAVE_ALIGNED_64)
+ 	case SIZE_64K:
+ 		ret = stress_icache_64K(args);
+ 		break;
+ #endif
+ 	default:
+-#if defined(ALIGNED_64K_SUPPORTED)
++#if defined(HAVE_ALIGNED_64)
+ 		pr_inf("%s: page size %zu is not %u or %u or %u, cannot test\n",
+ 			args->name, args->page_size,
+ 			SIZE_4K, SIZE_16K, SIZE_64K);
+diff --git a/stress-ng.h b/stress-ng.h
+index 7b8ee7a..8b85581 100644
+--- a/stress-ng.h
++++ b/stress-ng.h
+@@ -343,7 +343,7 @@ typedef struct {
+ #endif
+ 
+ /* Force aligment to nearest cache line */
+-#if defined(__GNUC__) &&  NEED_GNUC(3,3,0)
++#if defined(HAVE_ALIGNED_64)
+ #define ALIGN64		__attribute__ ((aligned(64)))
+ #else
+ #define ALIGN64
+diff --git a/test-aligned-64.c b/test-aligned-64.c
+new file mode 100644
+index 0000000..4738e76
+--- /dev/null
++++ b/test-aligned-64.c
+@@ -0,0 +1,41 @@
++/*
++ * Copyright (C) 2017 Canonical, Ltd.
++ *
++ * This program is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU General Public License
++ * as published by the Free Software Foundation; either version 2
++ * of the License, or (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ * GNU General Public License for more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program; if not, write to the Free Software
++ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
++ *
++ * This code is a complete clean re-write of the stress tool by
++ * Colin Ian King <colin.king@canonical.com> and attempts to be
++ * backwardly compatible with the stress tool by Amos Waterland
++ * <apw@rossby.metr.ou.edu> but has more stress tests and more
++ * functionality.
++ *
++ */
++#include <stddef.h>
++
++int __attribute__ ((aligned(64))) test_align64(void);
++
++int main(void)
++{
++	const ptrdiff_t addr = (ptrdiff_t)test_align64;
++
++	(void)test_align64();
++
++	return addr & 63;
++}
++
++int __attribute__ ((aligned(64))) test_align64(void)
++{
++	return 0;
++}
+-- 
+2.7.4
+

--- a/recipes/stress-ng/files/0003-Makefile-add-missing-.PHONY-and-correct-spelling-of-.patch
+++ b/recipes/stress-ng/files/0003-Makefile-add-missing-.PHONY-and-correct-spelling-of-.patch
@@ -1,0 +1,51 @@
+From c418c58e19fd25559564b5442f037a2f3625ced8 Mon Sep 17 00:00:00 2001
+From: Colin Ian King <colin.king@canonical.com>
+Date: Tue, 28 Mar 2017 23:27:28 +0100
+Subject: [PATCH 3/4] Makefile: add missing .PHONY and correct spelling of
+ .PHONEY
+
+Signed-off-by: Colin Ian King <colin.king@canonical.com>
+---
+ Makefile | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/Makefile b/Makefile
+index cb05dea..84d8a83 100644
+--- a/Makefile
++++ b/Makefile
+@@ -667,6 +667,7 @@ apparmor-data.o: usr.bin.pulseaudio.eg
+ #
+ #  check if we have sys/capability.h
+ #
++.PHONY: have_sys_cap_h
+ have_sys_cap_h:
+ 	@$(CC) $(CPPFLAGS) test-cap.c -o test-cap 2> /dev/null || true
+ 	@if [ -f test-cap ]; then \
+@@ -679,6 +680,7 @@ have_sys_cap_h:
+ #
+ #  check if we can build vecmath related code
+ #
++.PHONY: have_vecmath
+ have_vecmath: stress-vecmath.c
+ 	@$(CC) $(CPPFLAGS) -DHAVE_VECMATH -c -o stress-vecmath-test.o stress-vecmath.c 2> /dev/null || true
+ 	@if [ -f stress-vecmath-test.o ]; then \
+@@ -691,6 +693,7 @@ have_vecmath: stress-vecmath.c
+ #
+ #  check if we can build atomic related code
+ #
++.PHONY: have_atomic
+ have_atomic: stress-atomic.c
+ 	@$(CC) $(CPPFLAGS) -DTEST_ATOMIC_BUILD -DHAVE_ATOMIC stress-atomic.c -o stress-atomic-test 2> /dev/null || true
+ 	@if [ -f stress-atomic-test ]; then \
+@@ -703,7 +706,7 @@ have_atomic: stress-atomic.c
+ #
+ #  check if we can build functions aligned to 64 byte boundaries
+ #
+-.PHONEY: have_aligned_64
++.PHONY: have_aligned_64
+ have_aligned_64: test-aligned-64.c
+ 	@$(CC) $(CPPFLAGS) test-aligned-64.c -o test-aligned-64 2> /dev/null || true
+ 	@if [ -f test-aligned-64 ]; then \
+-- 
+2.7.4
+

--- a/recipes/stress-ng/files/0004-Fix-test-for-64K-alignment-instead-of-64-byte.patch
+++ b/recipes/stress-ng/files/0004-Fix-test-for-64K-alignment-instead-of-64-byte.patch
@@ -1,0 +1,231 @@
+From 2c03776f1b20007ecc94d9d6c21658ac27dd905d Mon Sep 17 00:00:00 2001
+From: Colin Ian King <colin.king@canonical.com>
+Date: Wed, 29 Mar 2017 00:18:59 +0100
+Subject: [PATCH 4/4] Fix test for 64K alignment (instead of 64 byte)
+
+The test should be for 64K alignment and not 64 byte alignment,
+so fix this.
+
+This is what happens when one fixes a bug late at night on little
+sleep.
+
+Signed-off-by: Colin Ian King <colin.king@canonical.com>
+---
+ Makefile           | 26 +++++++++++++-------------
+ stress-icache.c    |  8 ++++----
+ stress-ng.h        |  2 +-
+ test-aligned-64.c  | 41 -----------------------------------------
+ test-aligned-64K.c | 41 +++++++++++++++++++++++++++++++++++++++++
+ 5 files changed, 59 insertions(+), 59 deletions(-)
+ delete mode 100644 test-aligned-64.c
+ create mode 100644 test-aligned-64K.c
+
+diff --git a/Makefile b/Makefile
+index 84d8a83..3e3fbbd 100644
+--- a/Makefile
++++ b/Makefile
+@@ -263,7 +263,7 @@ HAVE_NOT=HAVE_APPARMOR=0 HAVE_KEYUTILS_H=0 HAVE_XATTR_H=0 HAVE_LIB_BSD=0 \
+ 	 HAVE_LIB_Z=0 HAVE_LIB_CRYPT=0 HAVE_LIB_RT=0 HAVE_LIB_PTHREAD=0 \
+ 	 HAVE_FLOAT_DECIMAL=0 HAVE_SECCOMP_H=0 HAVE_LIB_AIO=0 HAVE_SYS_CAP_H=0 \
+ 	 HAVE_VECMATH=0 HAVE_ATOMIC=0 HAVE_LIB_SCTP=0 HAVE_ASM_NOP=0 \
+-	 HAVE_ALIGNED_64=0
++	 HAVE_ALIGNED_64K=0
+ 
+ #
+ #  Load in current config; use 'make clean' to clear this
+@@ -433,11 +433,11 @@ $(info autoconfig: using nop assembler instruction)
+ endif
+ endif
+ 
+-ifndef $(HAVE_ALIGNED_64)
+-HAVE_ALIGNED_64 = $(shell $(MAKE) --no-print-directory $(HAVE_NOT) have_aligned_64)
+-ifeq ($(HAVE_ALIGNED_64),1)
+-	CONFIG_CFLAGS += -DHAVE_ALIGNED_64
+-$(info autoconfig: using 64 byte alignment attribute)
++ifndef $(HAVE_ALIGNED_64K)
++HAVE_ALIGNED_64K = $(shell $(MAKE) --no-print-directory $(HAVE_NOT) have_aligned_64K)
++ifeq ($(HAVE_ALIGNED_64K),1)
++	CONFIG_CFLAGS += -DHAVE_ALIGNED_64K
++$(info autoconfig: using 64K byte alignment attribute)
+ endif
+ endif
+ 
+@@ -704,17 +704,17 @@ have_atomic: stress-atomic.c
+ 	@rm -rf stress-atomic-test
+ 
+ #
+-#  check if we can build functions aligned to 64 byte boundaries
++#  check if we can build functions aligned to 64K byte boundaries
+ #
+-.PHONY: have_aligned_64
+-have_aligned_64: test-aligned-64.c
+-	@$(CC) $(CPPFLAGS) test-aligned-64.c -o test-aligned-64 2> /dev/null || true
+-	@if [ -f test-aligned-64 ]; then \
++.PHONY: have_aligned_64K
++have_aligned_64K: test-aligned-64K.c
++	@$(CC) $(CPPFLAGS) test-aligned-64K.c -o test-aligned-64K 2> /dev/null || true
++	@if [ -f test-aligned-64K ]; then \
+ 		echo 1 ;\
+ 	else \
+ 		echo 0 ;\
+ 	fi
+-	@rm -rf test-aligned-64
++	@rm -rf test-aligned-64K
+ 
+ 
+ #
+@@ -764,7 +764,7 @@ dist:
+ 		test-apparmor.c test-libbsd.c test-libz.c \
+ 		test-libcrypt.c test-librt.c test-libpthread.c \
+ 		test-libaio.c test-cap.c test-libsctp.c \
+-		test-asm-nop.c test-aligned-64.c \
++		test-asm-nop.c test-aligned-64K.c \
+ 		usr.bin.pulseaudio.eg perf-event.c \
+ 		snapcraft smatchify.sh config TODO stress-ng-$(VERSION)
+ 	tar -zcf stress-ng-$(VERSION).tar.gz stress-ng-$(VERSION)
+diff --git a/stress-icache.c b/stress-icache.c
+index 599a381..28713b2 100644
+--- a/stress-icache.c
++++ b/stress-icache.c
+@@ -154,13 +154,13 @@ static inline int icache_madvise(const args_t *args, void *addr, size_t size)
+ 	return 0;
+ }
+ 
+-#if defined(HAVE_ALIGNED_64)
++#if defined(HAVE_ALIGNED_64K)
+ STRESS_ICACHE_FUNC(stress_icache_func_64K, SIZE_64K)
+ #endif
+ STRESS_ICACHE_FUNC(stress_icache_func_16K, SIZE_16K)
+ STRESS_ICACHE_FUNC(stress_icache_func_4K, SIZE_4K)
+ 
+-#if defined(HAVE_ALIGNED_64)
++#if defined(HAVE_ALIGNED_64K)
+ STRESS_ICACHE(stress_icache_64K, SIZE_64K, stress_icache_func_64K)
+ #endif
+ STRESS_ICACHE(stress_icache_16K, SIZE_16K, stress_icache_func_16K)
+@@ -184,13 +184,13 @@ int stress_icache(const args_t *args)
+ 	case SIZE_16K:
+ 		ret = stress_icache_16K(args);
+ 		break;
+-#if defined(HAVE_ALIGNED_64)
++#if defined(HAVE_ALIGNED_64K)
+ 	case SIZE_64K:
+ 		ret = stress_icache_64K(args);
+ 		break;
+ #endif
+ 	default:
+-#if defined(HAVE_ALIGNED_64)
++#if defined(HAVE_ALIGNED_64K)
+ 		pr_inf("%s: page size %zu is not %u or %u or %u, cannot test\n",
+ 			args->name, args->page_size,
+ 			SIZE_4K, SIZE_16K, SIZE_64K);
+diff --git a/stress-ng.h b/stress-ng.h
+index 8b85581..c5e43f6 100644
+--- a/stress-ng.h
++++ b/stress-ng.h
+@@ -343,7 +343,7 @@ typedef struct {
+ #endif
+ 
+ /* Force aligment to nearest cache line */
+-#if defined(HAVE_ALIGNED_64)
++#if defined(HAVE_ALIGNED_64K)
+ #define ALIGN64		__attribute__ ((aligned(64)))
+ #else
+ #define ALIGN64
+diff --git a/test-aligned-64.c b/test-aligned-64.c
+deleted file mode 100644
+index 4738e76..0000000
+--- a/test-aligned-64.c
++++ /dev/null
+@@ -1,41 +0,0 @@
+-/*
+- * Copyright (C) 2017 Canonical, Ltd.
+- *
+- * This program is free software; you can redistribute it and/or
+- * modify it under the terms of the GNU General Public License
+- * as published by the Free Software Foundation; either version 2
+- * of the License, or (at your option) any later version.
+- *
+- * This program is distributed in the hope that it will be useful,
+- * but WITHOUT ANY WARRANTY; without even the implied warranty of
+- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+- * GNU General Public License for more details.
+- *
+- * You should have received a copy of the GNU General Public License
+- * along with this program; if not, write to the Free Software
+- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+- *
+- * This code is a complete clean re-write of the stress tool by
+- * Colin Ian King <colin.king@canonical.com> and attempts to be
+- * backwardly compatible with the stress tool by Amos Waterland
+- * <apw@rossby.metr.ou.edu> but has more stress tests and more
+- * functionality.
+- *
+- */
+-#include <stddef.h>
+-
+-int __attribute__ ((aligned(64))) test_align64(void);
+-
+-int main(void)
+-{
+-	const ptrdiff_t addr = (ptrdiff_t)test_align64;
+-
+-	(void)test_align64();
+-
+-	return addr & 63;
+-}
+-
+-int __attribute__ ((aligned(64))) test_align64(void)
+-{
+-	return 0;
+-}
+diff --git a/test-aligned-64K.c b/test-aligned-64K.c
+new file mode 100644
+index 0000000..2b87e7e
+--- /dev/null
++++ b/test-aligned-64K.c
+@@ -0,0 +1,41 @@
++/*
++ * Copyright (C) 2017 Canonical, Ltd.
++ *
++ * This program is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU General Public License
++ * as published by the Free Software Foundation; either version 2
++ * of the License, or (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ * GNU General Public License for more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program; if not, write to the Free Software
++ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
++ *
++ * This code is a complete clean re-write of the stress tool by
++ * Colin Ian King <colin.king@canonical.com> and attempts to be
++ * backwardly compatible with the stress tool by Amos Waterland
++ * <apw@rossby.metr.ou.edu> but has more stress tests and more
++ * functionality.
++ *
++ */
++#include <stddef.h>
++
++int __attribute__ ((aligned(65536))) test_align64K(void);
++
++int main(void)
++{
++	const ptrdiff_t addr = (ptrdiff_t)test_align64K;
++
++	(void)test_align64K();
++
++	return addr & 65535;
++}
++
++int __attribute__ ((aligned(65536))) test_align64K(void)
++{
++	return 0;
++}
+-- 
+2.7.4
+

--- a/recipes/stress-ng/stress-ng.inc
+++ b/recipes/stress-ng/stress-ng.inc
@@ -1,0 +1,53 @@
+SUMMARY = "stress-ng tests a system by stressing the physical and kernel interfaces."
+
+DESCRIPTION = "stress-ng will stress test a computer system in various selectable ways. It was designed to exercise various physical subsystems of a computer as well as the various operating system kernel interfaces."
+
+LICENSE = "GPL-2.0+"
+HOMEPAGE = "http://kernel.ubuntu.com/~cking/stress-ng/"
+
+SRC_URI = "http://kernel.ubuntu.com/~cking/tarballs/stress-ng/stress-ng-${PV}.tar.gz"
+
+COMPATIBLE_HOST_ARCHS = ".*linux"
+
+inherit c make
+
+DEPS = "libm"
+
+# stress-ng is configured entirely by what is available at build
+# time. So we make USE flags for each piece that we may want to stage.
+DEPENDS += "${DEPS}"
+DEPENDS_${PN} = "${DEPS}"
+RDEPENDS_${PN} = "${DEPS}"
+
+# libcrypt, librt and libz are in all likelyhood already included in
+# the rootfs, so enable those by default.
+RECIPE_FLAGS += "stressng_crypt"
+DEFAULT_USE_stressng_crypt = True
+DEPS:>USE_stressng_crypt = " libcrypt"
+
+RECIPE_FLAGS += "stressng_rt"
+DEFAULT_USE_stressng_rt = True
+DEPS:>USE_stressng_rt = " librt"
+
+RECIPE_FLAGS += "stressng_z"
+DEFAULT_USE_stressng_z = True
+DEPS:>USE_stressng_z = " libz"
+
+# libcap requires opt-in.
+RECIPE_FLAGS += "stressng_cap"
+DEFAULT_USE_stressng_cap = False
+DEPS:>USE_stressng_cap = " libcap"
+
+# There are no upstream recipes for these, so enabling these requires
+# some additional work.
+RECIPE_FLAGS += "stressng_sctp"
+DEFAULT_USE_stressng_sctp = False
+DEPS:>USE_stressng_sctp = " libsctp"
+
+RECIPE_FLAGS += "stressng_aio"
+DEFAULT_USE_stressng_aio = False
+DEPS:>USE_stressng_aio = " libaio"
+
+RECIPE_FLAGS += "stressng_bsd"
+DEFAULT_USE_stressng_bsd = False
+DEPS:>USE_stressng_bsd = " libbsd"

--- a/recipes/stress-ng/stress-ng_0.07.27.oe
+++ b/recipes/stress-ng/stress-ng_0.07.27.oe
@@ -1,0 +1,11 @@
+require ${PN}.inc
+
+# On ARM, using binutils <= 2.25, the assembler complains that it's
+# not able to honour aligned(65536). These patches fix the problem by
+# checking whether the entire toolchain understands that, instead of
+# just checking for a new enough gcc. They are taken from upstream, so
+# will be unnecessary in the next version.
+
+SRC_URI += "file://0002-Add-autodetection-for-64-byte-alignment-of-functions.patch"
+SRC_URI += "file://0003-Makefile-add-missing-.PHONY-and-correct-spelling-of-.patch"
+SRC_URI += "file://0004-Fix-test-for-64K-alignment-instead-of-64-byte.patch"

--- a/recipes/stress-ng/stress-ng_0.07.27.oe.sig
+++ b/recipes/stress-ng/stress-ng_0.07.27.oe.sig
@@ -1,0 +1,1 @@
+aeaa4fe5119953992487a1e9e5440aab2c8431ac  stress-ng-0.07.27.tar.gz


### PR DESCRIPTION
There's a build problem on ARM with binutils < 2.26 (on my host which
has 2.26, I cannot reproduce it, but current meta/core is at 2.25). The
included patches are from upstream, so shouldn't be needed in the next
release.