### PR TITLE
busybox: add use flag for getopt utility

### DIFF
--- a/recipes/busybox/busybox-configure.inc
+++ b/recipes/busybox/busybox-configure.inc
@@ -577,6 +577,11 @@ BUSYBOX_SIMPLE_USE_FLAGS += "traceroute:util/"
 # USE flag: enable cttyhack utility
 BUSYBOX_SIMPLE_USE_FLAGS += "cttyhack:util/"
 
+# USE flag: enable getopt utility
+BUSYBOX_SIMPLE_USE_FLAGS += "getopt:util/:\
+CONFIG_GETOPT,\
+CONFIG_FEATURE_GETOPT_LONG"
+
 # USE flag: enable gzip utility
 BUSYBOX_SIMPLE_USE_FLAGS += "gzip=1:util/:\
 CONFIG_GZIP,\


### PR DESCRIPTION
The shell already provides the getopts builtin, but that only supports
short options. About the only reason one would want to enable the
getopt utility is to support long option parsing, so let the
busybox_getopt use flag also enable FEATURE_GETOPT_LONG instead of
making that a separate use flag.