### PR TITLE
dhcp: add s6 init support

### DIFF
--- a/recipes/dhcp/dhcp-4.3.5/disable-syslog.patch
+++ b/recipes/dhcp/dhcp-4.3.5/disable-syslog.patch
@@ -1,0 +1,233 @@
+Disable syslog the hard way: Put #if 0 around all calls of syslog and
+other functions declared in syslog.h.
+
+Also #if 0 out #includes of syslog.h itself, so that future additions
+of syslog calls hopefully make the build fail due to missing function
+or macro declarations.
+
+Exempt stables.c from this, to allow existing configuration files with
+a log-facility stanza to still parse.
+
+Origin: OE-lite
+Upstream-status: inappropriate (OE-lite specific)
+
+diff -u -r dhcp-4.3.5.orig/client/dhclient.c dhcp-4.3.5/client/dhclient.c
+--- dhcp-4.3.5.orig/client/dhclient.c	2017-05-19 10:19:42.101680565 +0200
++++ dhcp-4.3.5/client/dhclient.c	2017-05-19 10:40:55.408444413 +0200
+@@ -31,7 +31,9 @@
+  */
+ 
+ #include "dhcpd.h"
++#if 0 /* disable syslog */
+ #include <syslog.h>
++#endif /* disable syslog */
+ #include <signal.h>
+ #include <errno.h>
+ #include <sys/time.h>
+@@ -230,11 +232,13 @@
+ 	else if (fd != -1)
+ 		close(fd);
+ 
++#if 0 /* disable syslog */
+ 	openlog(isc_file_basename(progname), DHCP_LOG_OPTIONS, LOG_DAEMON);
+ 
+ #if !(defined(DEBUG) || defined(__CYGWIN32__))
+ 	setlogmask(LOG_UPTO(LOG_INFO));
+ #endif
++#endif /* disable syslog */
+ 
+ 	/* Set up the isc and dns library managers */
+ 	status = dhcp_context_create(DHCP_CONTEXT_PRE_DB | DHCP_CONTEXT_POST_DB,
+diff -u -r dhcp-4.3.5.orig/common/parse.c dhcp-4.3.5/common/parse.c
+--- dhcp-4.3.5.orig/common/parse.c	2017-05-19 10:19:42.237680889 +0200
++++ dhcp-4.3.5/common/parse.c	2017-05-19 10:23:19.542775302 +0200
+@@ -27,7 +27,9 @@
+  */
+ 
+ #include "dhcpd.h"
++#if 0
+ #include <syslog.h>
++#endif
+ 
+ /* Enumerations can be specified in option formats, and are used for
+    parsing, so we define the routines that manage them here. */
+@@ -5590,11 +5592,13 @@
+ 	lexbuf [lix] = 0;
+ 
+ #ifndef DEBUG
++#if 0
+ 	syslog (LOG_ERR, "%s", mbuf);
+ 	syslog (LOG_ERR, "%s", cfile -> token_line);
+ 	if (cfile -> lexchar < 81)
+ 		syslog (LOG_ERR, "%s^", lexbuf);
+ #endif
++#endif
+ 
+ 	if (log_perror) {
+ 		IGNORE_RET (write (STDERR_FILENO, mbuf, strlen (mbuf)));
+diff -u -r dhcp-4.3.5.orig/dhcpctl/omshell.c dhcp-4.3.5/dhcpctl/omshell.c
+--- dhcp-4.3.5.orig/dhcpctl/omshell.c	2017-05-19 10:19:42.241680898 +0200
++++ dhcp-4.3.5/dhcpctl/omshell.c	2017-05-19 10:36:36.167537732 +0200
+@@ -36,7 +36,9 @@
+ #include <stdarg.h>
+ #include <string.h>
+ //#include "result.h"
++#if 0 /* disable syslog */
+ #include <syslog.h>
++#endif /* disable syslog */
+ #include "dhcpctl.h"
+ #include "dhcpd.h"
+ #include <isc/file.h>
+@@ -108,8 +110,10 @@
+ 	}
+ 
+ 	/* Initially, log errors to stderr as well as to syslogd. */
++#if 0 /* disable syslog */
+ 	openlog (isc_file_basename(progname),
+ 		 DHCP_LOG_OPTIONS, DHCPD_LOG_FACILITY);
++#endif /* disable syslog */
+ 	status = dhcpctl_initialize ();
+ 	if (status != ISC_R_SUCCESS) {
+ 		fprintf (stderr, "dhcpctl_initialize: %s\n",
+diff -u -r dhcp-4.3.5.orig/includes/omapip/isclib.h dhcp-4.3.5/includes/omapip/isclib.h
+--- dhcp-4.3.5.orig/includes/omapip/isclib.h	2017-05-19 10:19:42.245680908 +0200
++++ dhcp-4.3.5/includes/omapip/isclib.h	2017-05-19 10:41:58.088593125 +0200
+@@ -30,7 +30,9 @@
+ 
+ #include "config.h"
+ 
++#if 0 /* disable syslog */
+ #include <syslog.h>
++#endif /* disable syslog */
+ 
+ #define MAXWIRE 256
+ 
+diff -u -r dhcp-4.3.5.orig/omapip/errwarn.c dhcp-4.3.5/omapip/errwarn.c
+--- dhcp-4.3.5.orig/omapip/errwarn.c	2017-05-19 10:19:42.245680908 +0200
++++ dhcp-4.3.5/omapip/errwarn.c	2017-05-19 10:39:41.444270214 +0200
+@@ -36,7 +36,9 @@
+ 
+ #include <omapip/omapip_p.h>
+ #include <errno.h>
++#if 0 /* disable syslog */
+ #include <syslog.h>
++#endif /* disable syslog */
+ 
+ #ifdef DEBUG
+ int log_perror = -1;
+@@ -65,7 +67,9 @@
+   va_end (list);
+ 
+ #ifndef DEBUG
++#if 0 /* disable syslog */
+   syslog (LOG_ERR, "%s", mbuf);
++#endif /* disable syslog */
+ #endif
+ 
+   /* Also log it to stderr? */
+@@ -104,7 +108,9 @@
+   va_end (list);
+ 
+ #ifndef DEBUG
++#if 0 /* disable syslog */
+   syslog (LOG_ERR, "%s", mbuf);
++#endif /* disable syslog */
+ #endif
+ 
+   if (log_perror) {
+@@ -131,7 +137,9 @@
+   va_end (list);
+ 
+ #ifndef DEBUG
++#if 0 /* disable syslog */
+   syslog (LOG_INFO, "%s", mbuf);
++#endif /* disable syslog */
+ #endif
+ 
+   if (log_perror) {
+@@ -158,7 +166,9 @@
+   va_end (list);
+ 
+ #ifndef DEBUG
++#if 0 /* disable syslog */
+   syslog (LOG_DEBUG, "%s", mbuf);
++#endif /* disable syslog */
+ #endif
+ 
+   if (log_perror) {
+diff -u -r dhcp-4.3.5.orig/relay/dhcrelay.c dhcp-4.3.5/relay/dhcrelay.c
+--- dhcp-4.3.5.orig/relay/dhcrelay.c	2017-05-19 10:19:42.245680908 +0200
++++ dhcp-4.3.5/relay/dhcrelay.c	2017-05-19 10:31:28.485744922 +0200
+@@ -27,7 +27,9 @@
+  */
+ 
+ #include "dhcpd.h"
++#if 0 /* disable syslog */
+ #include <syslog.h>
++#endif /* disable syslog */
+ #include <signal.h>
+ #include <sys/time.h>
+ #include <isc/file.h>
+@@ -250,11 +252,13 @@
+ 	else if (fd != -1)
+ 		close(fd);
+ 
++#if 0 /* disable syslog */
+ 	openlog(isc_file_basename(progname), DHCP_LOG_OPTIONS, LOG_DAEMON);
+ 
+ #if !defined(DEBUG)
+ 	setlogmask(LOG_UPTO(LOG_INFO));
+ #endif	
++#endif /* disable syslog */
+ 
+ 	/* Set up the isc and dns library managers */
+ 	status = dhcp_context_create(DHCP_CONTEXT_PRE_DB | DHCP_CONTEXT_POST_DB,
+diff -u -r dhcp-4.3.5.orig/server/dhcpd.c dhcp-4.3.5/server/dhcpd.c
+--- dhcp-4.3.5.orig/server/dhcpd.c	2017-05-19 10:19:42.249680917 +0200
++++ dhcp-4.3.5/server/dhcpd.c	2017-05-19 10:35:42.999231871 +0200
+@@ -35,7 +35,9 @@
+ 
+ #include "dhcpd.h"
+ #include <omapip/omapip_p.h>
++#if 0 /* disable syslog */
+ #include <syslog.h>
++#endif /* disable syslog */
+ #include <signal.h>
+ #include <errno.h>
+ #include <limits.h>
+@@ -292,8 +294,10 @@
+ 	dhcp_common_objects_setup ();
+ 
+ 	/* Initially, log errors to stderr as well as to syslogd. */
++#if 0 /* disable syslog */
+ 	openlog (isc_file_basename(progname),
+ 		 DHCP_LOG_OPTIONS, DHCPD_LOG_FACILITY);
++#endif /* disable syslog */
+ 
+ 	for (i = 1; i < argc; i++) {
+ 		if (!strcmp (argv [i], "-p")) {
+@@ -1164,9 +1168,11 @@
+ 		if (evaluate_option_cache(&db, NULL, NULL, NULL, options, NULL,
+ 					  &global_scope, oc, MDL)) {
+ 			if (db.len == 1) {
++#if 0 /* disable syslog */
+ 				closelog ();
+ 				openlog(isc_file_basename(progname),
+ 					DHCP_LOG_OPTIONS, db.data[0]);
++#endif /* disable syslog */
+ 				/* Log the startup banner into the new
+ 				   log file. */
+ 				/* Don't log to stderr twice. */
+diff -u -r dhcp-4.3.5.orig/server/stables.c dhcp-4.3.5/server/stables.c
+--- dhcp-4.3.5.orig/server/stables.c	2017-05-19 10:19:42.249680917 +0200
++++ dhcp-4.3.5/server/stables.c	2017-05-19 10:58:04.518855144 +0200
+@@ -27,7 +27,9 @@
+  */
+ 
+ #include "dhcpd.h"
++#if 1 /* don't disable syslog.h inclusion in this file! */
+ #include <syslog.h>
++#endif
+ 
+ #if defined (FAILOVER_PROTOCOL)
+ 

--- a/recipes/dhcp/dhcp4.inc
+++ b/recipes/dhcp/dhcp4.inc
@@ -102,3 +102,9 @@ EXTRA_OECONF += "${EXTRA_OECONF_OPENSSL}"
 EXTRA_OECONF_OPENSSL += ""
 EXTRA_OECONF_OPENSSL:USE_bind_openssl = 'LIBS="-lssl -lcrypto"'
 DEPENDS:>USE_bind_openssl = " ${CRYPTO_DEPENDS}"
+
+inherit s6rc
+S6RC_LONGRUN_SERVICES = "dhcpd dhcpd-log"
+SRC_URI += "file://dhcpd.run file://dhcpd-log.run"
+DEFAULT_USE_ntpd_s6rc_dependencies = "dhcpd-log net"
+FILES_${PN}-server += "${s6rcsrcdir}"

--- a/recipes/dhcp/dhcp_4.3.5.oe
+++ b/recipes/dhcp/dhcp_4.3.5.oe
@@ -3,6 +3,8 @@ require dhcp4.inc
 SRC_URI += "file://dhclient-script-drop-resolv.conf.dhclient.patch \
             file://replace-ifconfig-route.patch \
 "
+RECIPE_FLAGS += "dhcp_disable_syslog"
+SRC_URI:>USE_dhcp_disable_syslog = " file://disable-syslog.patch"
 
 DEPENDS += "bind-dev"
 EXTRA_OECONF += "--with-libbind=${TARGET_SYSROOT}${target_libdir}/../ --with-randomdev=/dev/random"

--- a/recipes/dhcp/dhcp_4.3.5.oe
+++ b/recipes/dhcp/dhcp_4.3.5.oe
@@ -3,7 +3,6 @@ require dhcp4.inc
 SRC_URI += "file://dhclient-script-drop-resolv.conf.dhclient.patch \
             file://replace-ifconfig-route.patch \
 "
-SRC_URI += "${SRC_URI_EXTRA}"
 
 DEPENDS += "bind-dev"
 EXTRA_OECONF += "--with-libbind=${TARGET_SYSROOT}${target_libdir}/../ --with-randomdev=/dev/random"

--- a/recipes/dhcp/files/dhcpd-log.run
+++ b/recipes/dhcp/files/dhcpd-log.run
@@ -1,0 +1,9 @@
+#!/bin/execlineb -P
+if { if -t -n { test -e /var/log/dhcpd }
+  install -d -o nobody -g nogroup -m 755 /var/log/dhcpd }
+if { if -t -n { test -e /run/dhcpd-log.fifo }
+  mkfifo /run/dhcpd-log.fifo }
+redirfd -rnb 0 /run/dhcpd-log.fifo
+s6-setuidgid nobody
+exec -c
+s6-log -b -- s131072 t /var/log/dhcpd

--- a/recipes/dhcp/files/dhcpd.run
+++ b/recipes/dhcp/files/dhcpd.run
@@ -1,0 +1,4 @@
+#!/bin/execlineb -P
+redirfd -w 1 /run/dhcpd-log.fifo
+fdmove -c 2 1
+/usr/sbin/dhcpd --no-pid -f -d


### PR DESCRIPTION
--no-pid is self-explanatory

-f means don't fork

-d means log to stderr (which actually implies -f, but it's better to be
explicit).

Unfortunately, there's no option to make dhcpd not use syslog(3), so
that would require patching dhcpd. Alternatively, one can decide that
e.g. LOG_LOCAL7 (and making sure to set 'log-facility local7' in
dhcpd.conf) messages should be filtered away by one's syslogd
replacement, so that they at least don't take up disk space twice.

Signed-off-by: Rasmus Villemoes <rasmus.villemoes@prevas.dk>