### PR TITLE
vsftpd: add s6 init support

### DIFF
--- a/recipes/vsftpd/files/vsftpd-log.run
+++ b/recipes/vsftpd/files/vsftpd-log.run
@@ -1,0 +1,9 @@
+#!/bin/execlineb -P
+if { if -t -n { test -e /var/log/vsftpd }
+  install -d -o nobody -g nogroup -m 755 /var/log/vsftpd }
+if { if -t -n { test -e /run/vsftpd-log.fifo }
+  mkfifo /run/vsftpd-log.fifo }
+redirfd -rnb 0 /run/vsftpd-log.fifo
+s6-setuidgid nobody
+exec -c
+s6-log -b -- s131072 t /var/log/vsftpd

--- a/recipes/vsftpd/files/vsftpd.run
+++ b/recipes/vsftpd/files/vsftpd.run
@@ -1,0 +1,9 @@
+#!/bin/execlineb -P
+redirfd -w 1 /run/vsftpd-log.fifo
+fdmove -c 2 1
+/usr/sbin/vsftpd
+  -obackground=NO -olisten=YES
+  -ovsftpd_log_file=/run/vsftpd-log.fifo
+  -oxferlog_file=/run/vsftpd-log.fifo
+  -oxferlog_enable=YES
+  -oxferlog_std_format=NO

--- a/recipes/vsftpd/vsftpd.inc
+++ b/recipes/vsftpd/vsftpd.inc
@@ -93,6 +93,15 @@ PACKAGES =+ "${PN}-init"
 RDEPENDS_${PN}:>USE_sysvinit += "${PN}-init"
 FILES_${PN}-init = "${sysconfdir}/init.d ${sysconfdir}/rc?.d"
 
+inherit s6rc
+S6RC_LONGRUN_SERVICES = "vsftpd vsftpd-log"
+SRC_URI += "file://vsftpd.run file://vsftpd-log.run"
+RECIPE_FLAGS += "vsftpd_s6rc_dependencies"
+DEFAULT_USE_vsftpd_s6rc_dependencies = "vsftpd-log net"
+PACKAGES += "${PN}-s6"
+FILES_${PN}-s6 += "${s6rcsrcdir}"
+RDEPENDS_${PN}:>USE_s6rc += " ${PN}-s6"
+
 # FIXME: do something else!
 #pkg_postinst() {
 #    if [ "x$D" != "x" ]; then


### PR DESCRIPTION
vsftpd has no way of getting it to log to stdout/stderr. Instead, we
have to tell it to write to the fifo s6-log is reading from. Setting
these on the command line means one doesn't have to deal with this in
the .conf file. It doesn't actually appear to ever write anything to
stdout/stderr, so one might want to redirect those to /dev/null, but I
suppose having them point at the fifo doesn't hurt.

Note that vsftpd reads the default configuration file (/etc/vsftpd.conf)
after parsing the command line if (and only if) no configuration files
were given on the command line.

The one logging-related thing one might do in the .conf file is to set
xferlog_std_format=YES if one wants wu-ftpd compatible logs (whatever
that means).