### PR TITLE
openvpn: add s6 init support

### DIFF
--- a/recipes/openvpn/files/openvpn-log.run
+++ b/recipes/openvpn/files/openvpn-log.run
@@ -1,0 +1,9 @@
+#!/bin/execlineb -P
+if { if -t -n { test -e /var/log/openvpn }
+  install -d -o nobody -g nogroup -m 755 /var/log/openvpn }
+if { if -t -n { test -e /run/openvpn-log.fifo }
+  mkfifo /run/openvpn-log.fifo }
+redirfd -rnb 0 /run/openvpn-log.fifo
+s6-setuidgid nobody
+exec -c
+s6-log -b -- s131072 t /var/log/openvpn

--- a/recipes/openvpn/files/openvpn.hook
+++ b/recipes/openvpn/files/openvpn.hook
@@ -1,0 +1,13 @@
+#!/bin/execlineb
+
+elgetpositionals
+backtick -n hooksdir { dirname $0 }
+import -u hooksdir
+define basename openvpn@
+define templatedir ${hooksdir}/${basename}.d
+elglob -s -0 confs /etc/openvpn/*.conf
+forx conffile { $confs }
+import -u conffile
+backtick -n name { basename ${conffile} .conf }
+import -u name
+cp -r ${templatedir}/ ${1}/${basename}${name}/

--- a/recipes/openvpn/files/openvpn.run
+++ b/recipes/openvpn/files/openvpn.run
@@ -1,0 +1,9 @@
+#!/bin/execlineb -P
+redirfd -w 1 /run/openvpn-log.fifo
+fdmove -c 2 1
+backtick -n name {
+  pipeline { getcwd cwd import cwd basename $cwd }
+  sed -e "s/openvpn@//"
+}
+import -u name
+openvpn --echo "Starting openvpn@${name}" --config /etc/openvpn/${name}.conf

--- a/recipes/openvpn/openvpn.inc
+++ b/recipes/openvpn/openvpn.inc
@@ -26,3 +26,30 @@ RDEPENDS_${PN} = "libc libgcc ${DEPENDS}"
 
 FILES_${PN}-dev += "${libdir}/openvpn/plugins/*.la"
 FILES_${PN}-dbg += "${libdir}/openvpn/plugins/.debug"
+
+inherit s6rc
+SRC_URI += "\
+  file://${PN}.hook \
+  file://${PN}.run \
+  file://${PN}-log.run \
+"
+
+S6RC_LONGRUN_SERVICES += "openvpn-log"
+RECIPE_FLAGS += "openvpn_s6rc_dependencies"
+DEFAULT_USE_openvpn_s6rc_dependencies = "openvpn-log net"
+do_install_s6[expand] = 3
+do_install_s6() {
+    mkdir -p "${D}${sysconfdir}/rc.hooks/${PN}@.d"
+    install -m 0755 "${SRCDIR}/${PN}.hook" \
+	    "${D}${sysconfdir}/rc.hooks/${PN}"
+    install -m 0755 "${SRCDIR}/${PN}.run" \
+	    "${D}${sysconfdir}/rc.hooks/${PN}@.d/run"
+    echo longrun > "${D}${sysconfdir}/rc.hooks/${PN}@.d/type"
+    for dep in ${USE_openvpn_s6rc_dependencies} ; do
+        echo "$dep" >> "${D}${sysconfdir}/rc.hooks/${PN}@.d/dependencies"
+    done
+}
+do_install[postfuncs] += "do_install_s6"
+PACKAGES =+ "${PN}-s6"
+FILES_${PN}-s6 = "${sysconfdir}/rc.hooks ${s6rcsrcdir}"
+RDEPENDS_${PN}:>USE_s6rc += " ${PN}-s6"


### PR DESCRIPTION
Use the rc.hooks mechanism to create one openvpn service for each
configuration file found in /etc/openvpn/. For now, let them all use the
same logger; that should be easy enough to change if required.

I've tested that the services are created as expected for each .conf
file, but I don't have an example .conf to test whether the service
actually works (I do get complaints in the log about an incomplete
configuration, though, so the logging seems to work).