### PR TITLE
jq: add use flag for setting --disable-maintainer-mode

### DIFF
--- a/recipes/jq/jq.inc
+++ b/recipes/jq/jq.inc
@@ -21,3 +21,5 @@ AUTO_PACKAGE_LIBS = "jq"
 AUTO_PACKAGE_LIBS_DEPENDS = "${DEPS}"
 AUTO_PACKAGE_LIBS_RDEPENDS = "${DEPS}"
 FILES_jq-libjq-dev += "${includedir}"
+
+EXTRA_OECONF += "--disable-maintainer-mode"


### PR DESCRIPTION
When the host's bison is < 3.0, do_configure complains

  configure: error: You need bison version 3.0 or greater, or use --disable-maintainer-mode.

Add a knob to add that configuration option.