### PR TITLE
overlay-files: allow symlinking to a directory

### DIFF
--- a/recipes/overlay-files/files/overlay.sh
+++ b/recipes/overlay-files/files/overlay.sh
@@ -18,7 +18,7 @@ for file in $OVERLAY_FILES ; do
     if test -e "$overlay_file" ; then
 	if test ! -h "$link_file" -o \
 	"`readlink "$link_file"`" != "$overlay_file" ; then
-	    ln -sf "$overlay_file" "$link_file"
+	    ln -sfnT "$overlay_file" "$link_file"
 	fi
     fi
 done


### PR DESCRIPTION
If /etc/openvpn already exists as a symlink to
/etc/openvpn.default, doing

  ln -sf /some/where /etc/openvpn

ends up creating the link where inside /etc/openvpn.default, rather than
making /etc/openvpn itself a symlink to /some/where. Add -n to avoid
dereferencing the target.

If /etc/openvpn is itself a directory, this will still end up creating
the symlink inside that directory, but this at least fixes the common
case where the symlink openvpn->openvpn.default has been created by
do_rstage_overlay_files.