### PR TITLE
ntp tweaks

### DIFF
--- a/recipes/ntp/files/ntp.conf
+++ b/recipes/ntp/files/ntp.conf
@@ -11,3 +11,12 @@ server 2.pool.ntp.org iburst
 server 3.pool.ntp.org iburst
 # Defining a default security setting
 restrict default nomodify nopeer
+
+# When using -x, the man page says: "Note: The kernel time discipline
+# is disabled with this option.". Experimentally, that seems to imply
+# that ntpd simply no longer steers the system clock in any way,
+# except perhaps for an initial jump if the time is off by more than
+# 10 minutes. Revert the effect of that part of the -x option by
+# explicitly enabling the kernel time discipline (i.e. setting
+# approprite frequency adjust values via adjtimex(2)).
+enable kernel

--- a/recipes/ntp/files/ntp.conf
+++ b/recipes/ntp/files/ntp.conf
@@ -5,6 +5,9 @@ driftfile /etc/ntp.drift
 # This obtains a random server which will be close
 # (in IP terms) to the machine.  Add other servers
 # as required, or change this.
-server pool.ntp.org
+server 0.pool.ntp.org iburst
+server 1.pool.ntp.org iburst
+server 2.pool.ntp.org iburst
+server 3.pool.ntp.org iburst
 # Defining a default security setting
 restrict default nomodify nopeer

--- a/recipes/ntp/files/ntp.conf
+++ b/recipes/ntp/files/ntp.conf
@@ -10,7 +10,9 @@ server 1.pool.ntp.org iburst
 server 2.pool.ntp.org iburst
 server 3.pool.ntp.org iburst
 # Defining a default security setting
-restrict default nomodify nopeer
+restrict default ignore
+# Ensure localhost can talk to ntpd
+restrict 127.0.0.1
 
 # When using -x, the man page says: "Note: The kernel time discipline
 # is disabled with this option.". Experimentally, that seems to imply

--- a/recipes/ntp/files/ntpd
+++ b/recipes/ntp/files/ntpd
@@ -1,10 +1,11 @@
 #! /bin/sh
 #
 
+DAEMON=/usr/bin/ntpd
 ntpd_start_args="NTPD_START_ARGS_PLACEHOLDER"
 
 # ntpd	init.d script for ntpdc from ntp.isc.org
-test -x /usr/bin/ntpd -a -r /etc/ntp.conf || exit 0
+test -x $DAEMON -a -r /etc/ntp.conf || exit 0
 # rcS contains TICKADJ
 test -r /etc/default/rcS && . /etc/default/rcS
 
@@ -24,12 +25,12 @@ startdaemon(){
 	# this.  If ntpd seems to disappear after a while assume TICKADJ
 	# above is set to a totally incorrect value.
 	echo -n "Starting ntpd: "
-	start-stop-daemon --start -x /usr/bin/ntpd -- -p /var/run/ntp.pid "$@"
+	start-stop-daemon --start -x $DAEMON -- -p /var/run/ntp.pid "$@"
 	echo "done"
 }
 stopdaemon(){
 	echo -n "Stopping ntpd: "
-	start-stop-daemon --stop -p /var/run/ntp.pid
+	start-stop-daemon --stop -x $DAEMON
 	echo "done"
 }
 

--- a/recipes/ntp/ntpstat/0001-ntpstat-0.2-clksrc.patch
+++ b/recipes/ntp/ntpstat/0001-ntpstat-0.2-clksrc.patch
@@ -1,0 +1,12 @@
+diff -up ntp-4.2.4p7/ntpstat-0.2/ntpstat.c.ntpstat ntp-4.2.4p7/ntpstat-0.2/ntpstat.c
+--- ntp-4.2.4p7/ntpstat-0.2/ntpstat.c.ntpstat	2002-06-10 08:02:12.000000000 +0200
++++ ntp-4.2.4p7/ntpstat-0.2/ntpstat.c	2009-07-20 12:22:35.000000000 +0200
+@@ -187,7 +187,7 @@ int main (void) {
+     else
+       printf("unknown source");
+ 
+-    if (!strncmp(clksrcname[clksrc],clksrcname[6],sizeof(clksrcname[6]))) {
++    if (clksrc == 6) {
+       // source of sync is another NTP server so check the IP address
+       strncpy(buff, ntpmsg.payload, sizeof(buff));
+       if ((newstr = strstr (buff, REFID))) {

--- a/recipes/ntp/ntpstat/0002-ntpstat-0.2-multipacket.patch
+++ b/recipes/ntp/ntpstat/0002-ntpstat-0.2-multipacket.patch
@@ -1,0 +1,12 @@
+diff -up ntp-4.2.4p7/ntpstat-0.2/ntpstat.c.ntpstat ntp-4.2.4p7/ntpstat-0.2/ntpstat.c
+--- ntp-4.2.4p7/ntpstat-0.2/ntpstat.c.ntpstat	2002-06-10 08:02:12.000000000 +0200
++++ ntp-4.2.4p7/ntpstat-0.2/ntpstat.c	2009-07-20 12:22:35.000000000 +0200
+@@ -151,7 +151,7 @@ int main (void) {
+   /* For the reply message to be valid, the first byte should be as sent, 
+      and the second byte should be the same, with the response bit set */
+   byte1ok = ((ntpmsg.byte1&0x3F) == B1VAL);
+-  byte2ok = (ntpmsg.byte2 == (B2VAL|RMASK));
++  byte2ok = ((ntpmsg.byte2 & ~MMASK) == (B2VAL|RMASK));
+   if (!(byte1ok && byte2ok)) {
+     fprintf (stderr,"status word is 0x%02x%02x\n", ntpmsg.byte1,ntpmsg.byte2 );
+     die ("return data appears to be invalid based on status word");

--- a/recipes/ntp/ntpstat/0003-ntpstat-0.2-sysvars.patch
+++ b/recipes/ntp/ntpstat/0003-ntpstat-0.2-sysvars.patch
@@ -1,0 +1,15 @@
+diff -up ntp-4.2.6p1/ntpstat-0.2/ntpstat.c.sysvars ntp-4.2.6p1/ntpstat-0.2/ntpstat.c
+--- ntp-4.2.6p1/ntpstat-0.2/ntpstat.c.sysvars	2010-05-03 11:27:47.000000000 +0200
++++ ntp-4.2.6p1/ntpstat-0.2/ntpstat.c	2010-05-03 11:32:56.000000000 +0200
+@@ -89,9 +89,9 @@ int main (void) {
+     "modem"};         /* 9 */
+   char *newstr;
+   char *dispstr;
+-  const char DISP[] = "rootdispersion=";
++  const char DISP[] = "rootdisp=";
+   const char STRATUM[] = "stratum=";
+-  const char POLL[] = "poll=";
++  const char POLL[] = "tc=";
+   const char REFID[] = "refid=";
+ 
+   /* initialise timeout value */

--- a/recipes/ntp/ntpstat/0004-ntpstat-0.2-maxerror.patch
+++ b/recipes/ntp/ntpstat/0004-ntpstat-0.2-maxerror.patch
@@ -1,0 +1,38 @@
+diff -up ntp-4.2.6p1/ntpstat-0.2/ntpstat.c.maxerror ntp-4.2.6p1/ntpstat-0.2/ntpstat.c
+--- ntp-4.2.6p1/ntpstat-0.2/ntpstat.c.maxerror	2010-05-03 11:37:49.000000000 +0200
++++ ntp-4.2.6p1/ntpstat-0.2/ntpstat.c	2010-05-03 12:20:08.000000000 +0200
+@@ -89,7 +89,9 @@ int main (void) {
+     "modem"};         /* 9 */
+   char *newstr;
+   char *dispstr;
++  char *delaystr;
+   const char DISP[] = "rootdisp=";
++  const char DELAY[] = "rootdelay=";
+   const char STRATUM[] = "stratum=";
+   const char POLL[] = "tc=";
+   const char REFID[] = "refid=";
+@@ -235,16 +237,19 @@ int main (void) {
+     /* Set the position of the start of the string to 
+        "rootdispersion=" part of the string. */
+     strncpy(buff, ntpmsg.payload, sizeof(buff));
+-    if ((newstr = strstr (buff, DISP))) {
+-      newstr += sizeof(DISP) - 1;
+-      dispstr = strtok(newstr,".");
++    if ((dispstr = strstr (buff, DISP)) && (delaystr = strstr (buff, DELAY))) {
++      dispstr += sizeof(DISP) - 1;
++      dispstr = strtok(dispstr,",");
++      delaystr += sizeof(DELAY) - 1;
++      delaystr = strtok(delaystr,",");
+ 
+       /* Check the resultant string is of a reasonable length */
+-      if ((strlen (dispstr) == 0) || (strlen (dispstr) > 4)) {
++      if ((strlen (dispstr) == 0) || (strlen (dispstr) > 10) ||
++	      (strlen (delaystr) == 0) || (strlen (delaystr) > 10)) {
+ 	printf ("accuracy unreadable\n");
+       }
+       else {
+-	printf("   time correct to within %s ms\n",dispstr);
++	printf("   time correct to within %.0f ms\n", atof(dispstr) + atof(delaystr) / 2.0);
+       }
+     } else {
+       rc=1;

--- a/recipes/ntp/ntpstat/0005-ntpstat-0.2-errorbit.patch
+++ b/recipes/ntp/ntpstat/0005-ntpstat-0.2-errorbit.patch
@@ -1,0 +1,32 @@
+diff -up ntp-4.2.6p4/ntpstat-0.2/ntpstat.c.errorbit ntp-4.2.6p4/ntpstat-0.2/ntpstat.c
+--- ntp-4.2.6p4/ntpstat-0.2/ntpstat.c.errorbit	2011-10-06 13:41:38.591669772 +0200
++++ ntp-4.2.6p4/ntpstat-0.2/ntpstat.c	2011-10-06 16:50:01.708315811 +0200
+@@ -104,6 +104,7 @@ int main (void) {
+   FD_ZERO(&fds);
+ 
+   inet_aton("127.0.0.1", &address);
++  memset(&sock, 0, sizeof (sock));;
+   sock.sin_family = AF_INET;
+   sock.sin_addr = address;
+   sock.sin_port = htons(NTP_PORT);
+@@ -159,15 +160,18 @@ int main (void) {
+     die ("return data appears to be invalid based on status word");
+   }
+ 
+-  if (!(ntpmsg.byte2 | EMASK)) {
++  if (ntpmsg.byte2 & EMASK) {
+     fprintf (stderr,"status byte2 is %02x\n", ntpmsg.byte2 );
+     die ("error bit is set in reply");
+   }
+ 
+-  if (!(ntpmsg.byte2 | MMASK)) {
++  /* ignore the more bit */
++#if 0
++  if (ntpmsg.byte2 & MMASK) {
+     fprintf (stderr,"status byte2 is %02x\n", ntpmsg.byte2 );
+     fprintf (stderr,"More bit unexpected in reply");
+   }
++#endif
+ 
+   /* if the leap indicator (LI), which is the two most significant bits
+      in status byte1, are both one, then the clock is not synchronised. */

--- a/recipes/ntp/ntpstat/0006-ntpstat-0.2-manual.patch
+++ b/recipes/ntp/ntpstat/0006-ntpstat-0.2-manual.patch
@@ -1,0 +1,41 @@
+diff -up ntp-4.2.6p5/ntpstat-0.2/ntpstat.1.manual ntp-4.2.6p5/ntpstat-0.2/ntpstat.1
+--- ntp-4.2.6p5/ntpstat-0.2/ntpstat.1.manual	2002-06-10 08:02:12.000000000 +0200
++++ ntp-4.2.6p5/ntpstat-0.2/ntpstat.1	2015-12-04 17:28:23.379793604 +0100
+@@ -1,4 +1,4 @@
+-.TH ntpstat 1 "$Date: 2001/06/22 03:27:10 $"
++.TH ntpstat 1
+ .UC 4
+ .SH NAME
+ ntpstat \- show network time synchronisation status
+@@ -6,12 +6,18 @@ ntpstat \- show network time synchronisa
+ .B ntpstat
+ .SH DESCRIPTION
+ .I ntpstat
+-will report the synchronisation state of the NTP daemon
++will report the synchronisation state of the NTP daemon (ntpd)
+ running on the local machine.  If the local system is found to be 
+ synchronised to a reference time source,  
+ .I ntpstat
+ will report the approximate time accuracy.
+ 
++When the synchronised state is reported, it means the system clock was updated
++at some point.  There is no timeout for this state.  It will stay there even
++when the source becomes unreachable and there are no other sources available.
++However, the reported accuracy will be slowly increasing, in the default ntpd
++configuration by 15 microseconds per second.
++
+ .SH RETURNS
+ .I ntpstat
+ returns 0 if clock is synchronised.
+@@ -22,7 +28,10 @@ returns 2 if clock state is indeterminan
+ if ntpd is not contactable.
+ 
+ .SH SEE ALSO
+-ntpdc, ntpdq
++.BR ntp_misc (5),
++.BR ntpd (8),
++.BR ntpq (8),
++.BR ntpdc (8)
+ 
+ .SH AUTHOR
+ G. Richard Keech (rkeech@redhat.com)

--- a/recipes/ntp/ntpstat/ntp_is_synced
+++ b/recipes/ntp/ntpstat/ntp_is_synced
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+# Usage:
+#
+# ntp_is_synced <threshold-in-ms>
+# ntp_is_synced
+#
+# The latter uses a default of 1000 ms.
+#
+# Never produces output. The return code is:
+#
+# 0: ntpd reports being synced to a remote, with accuracy < threshold
+# 1: ntpd reports being synced to a remote, with accuracy >= threshold
+# 2: some other error (e.g. ntpstat giving an error or unexpected output)
+
+threshold=1000
+if [ $# -gt 0 ] ; then
+    threshold=$1
+    shift
+fi
+
+tmp=$(mktemp)
+trap "rm -f '${tmp}'" EXIT
+if ! ntpstat > "${tmp}" 2> /dev/null || \
+   ! grep -q 'synchronised to NTP server' "${tmp}" ; then
+    exit 2
+fi
+
+acc="$(grep -E "time correct to within [0-9]+ ms" "${tmp}" | head -n1 | sed -e 's/^ *time correct to within \([0-9]*\).*/\1/' )"
+if [ -z "${acc}" ] ; then
+    exit 2
+fi
+if [ "${acc}" -lt "${threshold}" ] ; then
+    exit 0
+else
+    exit 1
+fi

--- a/recipes/ntp/ntpstat_0.2.oe
+++ b/recipes/ntp/ntpstat_0.2.oe
@@ -1,0 +1,32 @@
+LICENSE = "GPL-2.0"
+SRC_URI = "http://pkgs.fedoraproject.org/repo/pkgs/ntp/${PN}-${PV}.tgz/6b2bedefe2e7c63ea52609b222022121/${PN}-${PV}.tgz"
+
+COMPATIBLE_HOST_ARCHS = ".*linux"
+
+# Patches from Fedora, before they replaced ntpstat with a bash script.
+# git://pkgs.fedoraproject.org/ntp;commit=ddd025f
+SRC_URI += "\
+file://0001-ntpstat-0.2-clksrc.patch;striplevel=2 \
+file://0002-ntpstat-0.2-multipacket.patch;striplevel=2 \
+file://0003-ntpstat-0.2-sysvars.patch;striplevel=2 \
+file://0004-ntpstat-0.2-maxerror.patch;striplevel=2 \
+file://0005-ntpstat-0.2-errorbit.patch;striplevel=2 \
+file://0006-ntpstat-0.2-manual.patch;striplevel=2 \
+"
+
+inherit make
+do_unpack_fix_perm() {
+    chmod u+w ${S}/ntpstat.1
+}
+do_unpack[postfuncs] += "do_unpack_fix_perm"
+
+do_compile() {
+    oe_runmake CC='${CC}' CFLAGS='${CFLAGS}' "$@"
+}
+do_install() {
+    install -d ${D}${bindir}
+    install -m 0755 ntpstat ${D}${bindir}
+    install -d ${D}${mandir}/man1
+    install -m 0644 ntpstat.1 ${D}${mandir}/man1
+}
+PROVIDES_${PN} += "util/ntpstat"

--- a/recipes/ntp/ntpstat_0.2.oe
+++ b/recipes/ntp/ntpstat_0.2.oe
@@ -14,6 +14,8 @@ file://0005-ntpstat-0.2-errorbit.patch;striplevel=2 \
 file://0006-ntpstat-0.2-manual.patch;striplevel=2 \
 "
 
+SRC_URI += "file://ntp_is_synced"
+
 inherit make
 do_unpack_fix_perm() {
     chmod u+w ${S}/ntpstat.1
@@ -26,7 +28,9 @@ do_compile() {
 do_install() {
     install -d ${D}${bindir}
     install -m 0755 ntpstat ${D}${bindir}
+    install -m 0755 ${SRCDIR}/ntp_is_synced ${D}${bindir}
     install -d ${D}${mandir}/man1
     install -m 0644 ntpstat.1 ${D}${mandir}/man1
 }
 PROVIDES_${PN} += "util/ntpstat"
+PROVIDES_${PN} += "util/ntp_is_synced"

--- a/recipes/ntp/ntpstat_0.2.oe.sig
+++ b/recipes/ntp/ntpstat_0.2.oe.sig
@@ -1,0 +1,1 @@
+9b6baf20b5943651a6bf8d6cf9a78e318573b541  ntpstat-0.2.tgz


### PR DESCRIPTION
This fixes a few bugs in the default ntp.conf as well as the sysvinit script, and adds simple utilities that can be used to query ntpd for how accurate the system clock is.