### PR TITLE
s6-init: Add timeout to avoid s6-rc state machine block

### DIFF
--- a/recipes/s6-init/s6-init/service
+++ b/recipes/s6-init/s6-init/service
@@ -10,11 +10,11 @@ EOF
     }
 
 start() {
-    s6-rc -u change $*
+    s6-rc -u -t 10000 change $*
 }
 
 stop() {
-    s6-rc -d change $*
+    s6-rc -d -t 10000 change $*
 }
 
 if test -t 1 ; then


### PR DESCRIPTION
The s6-rc state machine will be blocked while the `s6-rc change` command is
running.  Without a timeout, we could thus block forever.

See https://www.mail-archive.com/supervision@list.skarnet.org/msg01683.html

And as reboot is handled as an s6-rc state machine transition, we will not
even be able to reboot in those cases.

This change introduces a hard-coded 10 second timeout service start and stop
commands.  If the timeout fires, any changes happening later will be picked up
by s6-rc on next `s6-rc change` call.

Signed-off-by: Esben Haabendal <esben@haabendal.dk>