### PR TITLE
openvpn: create bundle consisting of all openvpn@* services

### DIFF
--- a/recipes/openvpn/files/openvpn.hook
+++ b/recipes/openvpn/files/openvpn.hook
@@ -5,9 +5,14 @@ backtick -n hooksdir { dirname $0 }
 import -u hooksdir
 define basename openvpn@
 define templatedir ${hooksdir}/${basename}.d
+define allbundledir ${1}/openvpn
+if { mkdir ${allbundledir} }
+if { redirfd -w 1 ${allbundledir}/type s6-echo "bundle" }
+if { redirfd -w 1 ${allbundledir}/contents exit 0 }
 elglob -s -0 confs /etc/openvpn/*.conf
 forx conffile { $confs }
 import -u conffile
 backtick -n name { basename ${conffile} .conf }
 import -u name
-cp -r ${templatedir}/ ${1}/${basename}${name}/
+if { cp -r ${templatedir}/ ${1}/${basename}${name}/ }
+redirfd -a 1 ${allbundledir}/contents s6-echo ${basename}${name}


### PR DESCRIPTION
In addition to creating the openvpn@X services for each X.conf, also
create a bundle simply called openvpn that contains all of these
services.

The lack of -p in the mkdir command is deliberate; this ensures that
we're actually creating a new bundle and do not clobber some other
hook's output (the caller of the hook script is supposed to have created
the ${1} directory). We still need to create an empty contents file
explicitly in case there are no .conf files.