### PR TITLE
util-linux: allow compile-time changing of default --delay option

### DIFF
--- a/recipes/util-linux/util-linux_2.29.oe
+++ b/recipes/util-linux/util-linux_2.29.oe
@@ -111,3 +111,12 @@ RDEPENDS_${PN}-lsns += "libc libsmartcols"
 #lastb symlinks to last, uname26 symlinks to setarch
 RDEPENDS_${PN}-lastb += "${PN}-last"
 RDEPENDS_${PN}-uname26 += "${PN}-setarch"
+
+RECIPE_FLAGS += "hwclock_delay"
+hwclock_default_delay = "0.5"
+hwclock_default_delay:USE_hwclock_delay = "${USE_hwclock_delay}"
+do_patch_set_default_delay() {
+    sed -i 's/^\(static double RTC_SET_DELAY_SECS = \)0.5/\1${hwclock_default_delay}/' \
+      ${S}/sys-utils/hwclock.c
+}
+do_patch[postfuncs] += "do_patch_set_default_delay"


### PR DESCRIPTION
While the patch added in f485a62 made it possible to avoid losing
precision when doing hwclock --systohc, in practice it turns out to be
cumbersome to ensure that every call in an entire BSP passes the
appropriate --delay option.

So allow setting USE_hwclock_delay in e.g. a machine configuration. This
could probably replace the patch added in f485a62 (i.e., simply change
the hard-coded default, without adding a command-line switch to override
it), but partly because that's already merged, partly because there
might be hardware out there with two different RTCs that need different
--delay args, I'm just adding this on top.