### PR TITLE
s6-init: Fix use of USE_system_watchdog_device

### DIFF
--- a/recipes/s6-init/s6-init.oe
+++ b/recipes/s6-init/s6-init.oe
@@ -34,7 +34,7 @@ RECIPE_FLAGS += "system_watchdog_device"
 DEFAULT_USE_system_watchdog_device = "/dev/watchdog"
 do_configure[postfuncs] += "do_configure_system_watchdog"
 do_configure_system_watchdog() {
-	sed -e 's|-F [^ \t]*|${USE_system_watchdog_device}|' \
+	sed -e 's|-F [^ \t]*|-F ${USE_system_watchdog_device}|' \
 	    -i ${SRCDIR}/system-watchdog.run
 }
 


### PR DESCRIPTION
The `-F` flag should ofcourse not be dropped.

Signed-off-by: Esben Haabendal <esben@haabendal.dk>