### PR TITLE
s6-rc sanity checking

### DIFF
--- a/classes/s6rc-sanity.oeclass
+++ b/classes/s6rc-sanity.oeclass
@@ -1,0 +1,31 @@
+CLASS_FLAGS += "s6rc_sanity"
+IMAGE_PREPROCESS_FUNCS:>USE_s6rc_sanity = " image_preprocess_s6rc_sanity"
+CLASS_DEPENDS:>USE_s6rc_sanity = " native:s6-rc"
+
+image_preprocess_s6rc_sanity() {
+	test -d ./etc/rc || return 0
+	local ret=0
+	tmpd=$(mktemp -d)
+	cp -r ./etc/rc $tmpd/static
+
+	# We assume that each executable file in etc/rc.hooks creates
+	# a service or bundle by the same name. Some of the statically
+	# defined services in etc/rc may depend on some of these, so
+	# create empty bundles which cannot contribute to a dependency
+	# cycle.
+	mkdir -p $tmpd/dynamic
+	if [ -d ./etc/rc.hooks ] ; then
+		for f in $(find ./etc/rc.hooks -maxdepth 1 -type f -executable) ; do
+			b=$(basename $f)
+			d=$tmpd/dynamic/$b
+			mkdir -p $d
+			echo bundle > $d/type
+			touch $d/contents
+		done
+	fi
+
+	s6-rc-compile -v 2 $tmpd/compiled $tmpd/static $tmpd/dynamic && \
+	s6-rc-db -c $tmpd/compiled check || ret=1
+	rm -rf $tmpd
+	return $ret
+}

--- a/recipes/skaware/execline.inc
+++ b/recipes/skaware/execline.inc
@@ -5,6 +5,7 @@ LICENSE = "ISC"
 require compatible-archs.inc
 
 SRC_URI = "http://skarnet.org/software/${PN}/${PN}-${PV}.tar.gz"
+RECIPE_TYPES = "machine native"
 
 inherit c make
 

--- a/recipes/skaware/s6-rc.inc
+++ b/recipes/skaware/s6-rc.inc
@@ -4,6 +4,7 @@ LICENSE = "ISC"
 require compatible-archs.inc
 
 SRC_URI = "http://skarnet.org/software/${PN}/${PN}-${PV}.tar.gz"
+RECIPE_TYPES = "machine native"
 
 inherit c make
 

--- a/recipes/skaware/s6.inc
+++ b/recipes/skaware/s6.inc
@@ -6,6 +6,7 @@ LICENSE = "ISC"
 require compatible-archs.inc
 
 SRC_URI = "http://skarnet.org/software/${PN}/${PN}-${PV}.tar.gz"
+RECIPE_TYPES = "machine native"
 
 inherit c make
 

--- a/recipes/skaware/skalibs.inc
+++ b/recipes/skaware/skalibs.inc
@@ -9,6 +9,8 @@ SRC_URI = "http://skarnet.org/software/${PN}/${PN}-${PV}.tar.gz"
 inherit c make
 
 endianness = "${@['big', 'little'][d.get('HOST_ENDIAN') == 'l']}"
+librt_flag = ""
+librt_flag:native = "-lrt"
 
 # All supported archs need to have a sysdeps and sysdeps.h file.  These are
 # not provided by upstream, so we have to create them them ourselves when
@@ -18,7 +20,7 @@ do_configure[prefuncs] += "do_configure_sysdeps"
 do_configure_sysdeps() {
 	rm -rf ${B}/sysdeps
 	mkdir -p ${B}/sysdeps
-	echo "" > ${B}/sysdeps/rt.lib
+	echo "${librt_flag}" > ${B}/sysdeps/rt.lib
 	echo "" > ${B}/sysdeps/socket.lib
 	echo "" > ${B}/sysdeps/sysclock.lib
 	echo "" > ${B}/sysdeps/tainnow.lib

--- a/recipes/skaware/skalibs.inc
+++ b/recipes/skaware/skalibs.inc
@@ -5,6 +5,7 @@ LICENSE = "ISC"
 require compatible-archs.inc
 
 SRC_URI = "http://skarnet.org/software/${PN}/${PN}-${PV}.tar.gz"
+RECIPE_TYPES = "machine native"
 
 inherit c make
 


### PR DESCRIPTION
These three patches allow one to do a build-time check for cyclic dependencies and other errors in the s6 services by inheriting s6rc-sanity from one's rootfs recipe.