### PR TITLE
s6-init: prevent the syslogd filter script from buffering log lines

### DIFF
--- a/recipes/s6-init/s6-init/syslogd-srv.filter
+++ b/recipes/s6-init/s6-init/syslogd-srv.filter
@@ -1,3 +1,24 @@
-#!/bin/sed -f
-s/^\(<[0-9]\{1,3\}>\)\(Jan\|Feb\|Mar\|Apr\|May\|Jun\|Jul\|Aug\|Sep\|Oct\|Nov\|Dec\) [0-9 ]\{2\} [0-9]\{2\}\(:[0-9]\{2\}\)\{2\} /\1/
-/^$/d
+#!/usr/bin/awk -f
+#
+# While sed seems a saner choice, it turns out to be unsuitable for
+# "live" log filtering, since it (at least busybox sed) reads line n+1
+# before processing, let alone printing, line n.
+#
+# We want to do perl -pe 's/^(<[0-9]{1,3}>)regexp-matching-date /$1/'
+# . Lacking back-references, we cheat and double the facility/level
+# part so we can remove one copy of it. Lines not matching this
+# pattern are passed through as-is, except that we also filter away
+# empty lines.
+#
+# While busybox awk apparently always uses _IONBF or _IOLBF for its
+# stdout, GNU awk does buffer stdout when it is connected to a
+# pipe. Both support the fflush() function, which is now also
+# standardized in POSIX. Using that builtin rather than wrapping the
+# script in stdbuf -oL is more reliable, since there's no guarentee
+# that awk even uses libc's stdio facilities.
+
+/^<[0-9]{1,3}>(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) [0-9 ]{2} [0-9]{2}(:[0-9]{2}){2} / {
+	sub(/^<[0-9]{1,3}>/, "&&", $0);
+	sub(/<[0-9]{1,3}>(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) [0-9 ]{2} [0-9]{2}(:[0-9]{2}){2} /, "", $0);
+}
+/./ {print; fflush(); }


### PR DESCRIPTION
The current sed script ends up buffering its output, so that lines
arrive at the s6-log instance in batches, which means that the time
stamps they get have little to do with when the lines were produced, and
moreover there's obviously a greater chance of losing messages that way.

Prepending stdbuf -oL turns out to only partially solve the
problem. While busybox sed does happen to use libc's stdio, a quirk of
its implementation means that it reads line n+1 before processing (and
hence printing) line n, so there would be a delay of one line - and all
lines would be timestamped with a stamp that really belongs to the
following line.

This awk script seems to be equivalent, works with both busybox and
GNU awk, and explicitly flushes stdout after every print.