### PR TITLE
ntpd: avoid logging to syslog

### DIFF
--- a/recipes/ntp/files/ntpd.run
+++ b/recipes/ntp/files/ntpd.run
@@ -1,4 +1,4 @@
 #!/bin/execlineb -P
 redirfd -w 1 /run/ntpd-log.fifo
 fdmove -c 2 1
-/usr/sbin/ntpd -n NTPD_START_ARGS_PLACEHOLDER
+/usr/sbin/ntpd -n -l stderr NTPD_START_ARGS_PLACEHOLDER


### PR DESCRIPTION
Currently, the ntpd s6 service logs to both syslog and stderr. Reading
the source code, it turns out that giving "stdout" or "stderr" as
arguments to the logfile configuration directive (equivalently, the -l
option) are special cased to DTRT, and the presence of the -l option has
the side effect of suppressing syslog output.

It is most sensible to hardcode this option in the .run script rather
than relying on it being part of NTPD_START_ARGS_PLACEHOLDER, since
the script is already setting up stdout/stderr to point at the ntpd-log
companion service.