### PR TITLE
skalibs: Fix default path

### DIFF
--- a/recipes/s6-init/s6-init/init.stage1
+++ b/recipes/s6-init/s6-init/init.stage1
@@ -1,7 +1,7 @@
 #!/bin/execlineb
 
 # Make sure path and cwd is right
-/bin/export PATH /usr/bin:/bin:/usr/sbin:/sbin
+/bin/export PATH /sbin:/usr/sbin:/bin:/usr/bin
 cd /
 
 # Create background process group

--- a/recipes/skaware/skalibs.inc
+++ b/recipes/skaware/skalibs.inc
@@ -53,7 +53,7 @@ do_configure() {
 		--with-sysdeps=${B}/sysdeps \
 		--enable-clock \
 		--enable-monotonic \
-		--with-default-path="${sbindir}:${bindir}:${base_sbindir}:${base_bindir}" \
+		--with-default-path="${base_sbindir}:${sbindir}:${base_bindir}:${bindir}" \
 		${HOST_ARCH}
 }
 


### PR DESCRIPTION
This aligns default path with default (root) path in busybox, which is

    /sbin:/usr/sbin:/bin:/usr/bin

Signed-off-by: Esben Haabendal <esben@haabendal.dk>