### PR TITLE
dhcp: enable 'gentle shutdown'

### DIFF
--- a/recipes/dhcp/dhcp-4.3.5/0001-site.h-enable-gentle-shutdown.patch
+++ b/recipes/dhcp/dhcp-4.3.5/0001-site.h-enable-gentle-shutdown.patch
@@ -1,0 +1,25 @@
+Upstream-Status: Inappropriate [configuration]
+
+Subject: [PATCH] site.h: enable gentle shutdown
+
+Signed-off-by: Chen Qi <Qi.Chen@windriver.com>
+---
+ includes/site.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/includes/site.h b/includes/site.h
+index 1dd1251..abb66e4 100644
+--- a/includes/site.h
++++ b/includes/site.h
+@@ -289,7 +289,7 @@
+    situations.  We plan to revisit this feature and may
+    make non-backwards compatible changes including the
+    removal of this define.  Use at your own risk.  */
+-/* #define ENABLE_GENTLE_SHUTDOWN */
++#define ENABLE_GENTLE_SHUTDOWN
+ 
+ /* Include old error codes.  This is provided in case you
+    are building an external program similar to omshell for
+-- 
+2.8.1
+

--- a/recipes/dhcp/dhcp_4.3.5.oe
+++ b/recipes/dhcp/dhcp_4.3.5.oe
@@ -6,5 +6,7 @@ SRC_URI += "file://dhclient-script-drop-resolv.conf.dhclient.patch \
 RECIPE_FLAGS += "dhcp_disable_syslog"
 SRC_URI:>USE_dhcp_disable_syslog = " file://disable-syslog.patch"
 
+SRC_URI += "file://0001-site.h-enable-gentle-shutdown.patch"
+
 DEPENDS += "bind-dev"
 EXTRA_OECONF += "--with-libbind=${TARGET_SYSROOT}${target_libdir}/../ --with-randomdev=/dev/random"


### PR DESCRIPTION
Currently, dhcpd doesn't react to either SIGINT or SIGTERM. It has
handlers installed for these, and gdb says that they actually get called
and set the flag they're supposed to. But something in the event loop is
broken, so that flag is somehow not honoured.

Those signal handlers are actually installed in code linked in from
bind (lib/isc/unix/app.c), depending on a maze of ifdefs. On
Debian/Ubuntu, it turns out that isc__app_ctxstart gets monkey-patched
to return early just before any of the signal-handling business starts,
so dhcpd simply has the default action for SIGTERM.

Yocto solves this in another way, which is what we copy here. It turns out
that by setting ENABLE_GENTLE_SHUTDOWN in site.h, dhcpd itself installs
another handler for these, and that happens after the libbind init
calls, so they do take precedence. And that handler does seem to be
properly hooked into the event loop.

For reference, the patch itself is taken verbatim from
openembedded-core:

commit 2c789bac353e17637549a7b31706761ba848728e
Author: Chen Qi <Qi.Chen@windriver.com>
Date:   Tue Mar 15 14:39:40 2016 +0800

    dhcp: enable gentle shutdown

    For now, `systemctl stop dhcpd' cannot stop dhcpd correctly, the SIGTERM
    signal would time out, causing a SIGKILL signal sent to dhcpd.

    Patch site.h to enable gentle shutdown to so that dhcpd could be stopped
    by SIGTERM.

    Signed-off-by: Chen Qi <Qi.Chen@windriver.com>
    Signed-off-by: Ross Burton <ross.burton@intel.com>