### PR TITLE
enable some recipes for native

### DIFF
--- a/recipes/jansson/jansson.inc
+++ b/recipes/jansson/jansson.inc
@@ -2,6 +2,7 @@ DESCRIPTION = "Jansson is a C library for encoding, decoding and manipulating \
 JSON data"
 HOMEPAGE = "www.digip.org/jansson/"
 LICENSE = "MIT"
+RECIPE_TYPES = "machine native"
 
 SRC_URI = "http://www.digip.org/jansson/releases/jansson-${PV}.tar.bz2"
 

--- a/recipes/libnl/libnl.inc
+++ b/recipes/libnl/libnl.inc
@@ -2,6 +2,7 @@ DESCRIPTION = "A library for applications dealing with netlink sockets"
 HOMEPAGE = "http://www.infradead.org/~tgr/libnl/"
 
 COMPATIBLE_HOST_ARCHS = ".*linux"
+RECIPE_TYPES = "machine native"
 
 SRC_URI = "git://github.com/thom311/libnl.git;commit=${RELEASE_COMMIT}"
 


### PR DESCRIPTION
A certain project I'm working on uses jansson and libnl, and it's nice to be able to compile it for native as well as the target. native:jansson passes packageqa; native:libnl builds but does not pass packageqa, but neither does its machine: cousin currently.