### PR TITLE
netbase: avoid ifplugd writing to syslog

### DIFF
--- a/recipes/netbase/netbase/ifplugd.run
+++ b/recipes/netbase/netbase/ifplugd.run
@@ -8,4 +8,4 @@ backtick -n iface {
   sed -e "s/ifplugd@//"
 }
 import -u iface
-ifplugd -i $iface -n $ARGS -r /etc/ifplugd/ifplugd.action
+ifplugd -i $iface -n -s $ARGS -r /etc/ifplugd/ifplugd.action


### PR DESCRIPTION
We're already setting up stdout/stderr to go to the network-log service,
there's no point in having ifplugd write the same info to syslog. So
just as it makes sense to hardcode the -n (don't "daemonize") in the s6
run script, also hardcode -s (don't syslog), regardless of what $ARGS
happen to contain.