### PR TITLE
openssh: remove \r from log output

### DIFF
--- a/recipes/openssh/files/openssh-log.run
+++ b/recipes/openssh/files/openssh-log.run
@@ -7,5 +7,6 @@ redirfd -rnb 0 /run/openssh-log.fifo
 s6-setuidgid nobody
 if { fdmove 1 6 s6-echo ok }
 fdclose 6
+pipeline { tr -d "\r" }
 exec -c
 s6-log -b -- s131072 t /var/log/openssh

--- a/recipes/openssh/openssh.inc
+++ b/recipes/openssh/openssh.inc
@@ -142,4 +142,6 @@ do_install_HOST_KEYTYPES = ""
 do_install_HOST_KEYTYPES:USE_s6rc = "do_install_host_keytypes"
 do_install[postfuncs] += "${do_install_HOST_KEYTYPES}"
 
+RDEPENDS_${PN}-sshd:>USE_s6rc = " util/tr"
+
 PACKAGEQA_TARGET_BINDIRS += "${target_libexecdir}"


### PR DESCRIPTION
For non-obvious reasons, openssh ends all its stderr output with
"\r\n". We could try to patch that out, but I'm a little worried that
there's a reason openssh does it the way it does (maybe that code path
is sometimes used for something that goes over the wire and CRLF is
explicitly mentioned in the ssh spec). Instead, just make sure that what
hits s6-log doesn't contain CR.

One might argue that dos2unix would be a more appropriate filter, but at
least busybox dos2unix does exactly the same thing as tr -d '\r' (i.e.,
it removes all CR and not just those immediately preceding a LF).

Aside: in my first attempt, I used single-quotes, but execline doesn't
grok those, so tr got invoked with the three-character string
<squote><r><squote>, giving amusing log lines such as

  openssh: Seve listening on 0.0.0.0 pot 22.