### PR TITLE
openresolv: new recipe

### DIFF
--- a/recipes/openresolv/openresolv.inc
+++ b/recipes/openresolv/openresolv.inc
@@ -1,0 +1,45 @@
+SUMMARY = "DNS management framework"
+DESCRIPTION = "Resolvconf is a framework for keeping track of the system's \
+information about currently available nameservers. It sets \
+itself up as the intermediary between programs that supply \
+nameserver information and programs that need nameserver \
+information. \
+\
+This package is an alternative to Debian's resolvconf implementation \
+"
+LICENSE = "BSD-2-Clause"
+HOMEPAGE = "https://roy.marples.name/projects/openresolv"
+
+SRC_URI = "https://roy.marples.name/downloads/openresolv/openresolv-${PV}.tar.xz"
+
+# Not autotools, but with autotools-mostly-compatible configure script
+inherit autotools
+
+PROVIDES_${PN} += "util/resolvconf"
+PACKAGES =+ "${PN}-config"
+FILES_${PN}-config = "${sysconfdir}/resolvconf.conf"
+RDEPENDS_${PN} += "${PN}-config"
+
+do_install_sanitize_config() {
+  conf="${D}/${sysconfdir}/resolvconf.conf"
+
+  tweak() {
+    # The packaged one doesn't end in a newline, tsk tsk
+    echo ""
+
+    echo "### OE-lite default tweaks follow" >> $conf
+    echo "# Disable all hooks except libc" >> $conf
+    for hook in ${D}/${libexecdir}/* ; do
+      f=$(basename $hook)
+      if [ "$f" = libc ] ; then continue ; fi
+      echo "$f=no" >> $conf
+    done
+
+    echo "# Avoid doing an expensive and likely failing init system"
+    echo "# probing for how to restart \$libc_service aka nscd, which"
+    echo "# probably isn't running on target anyway."
+    echo "libc_restart=true"
+  }
+  tweak >> $conf
+}
+do_install[postfuncs] += "do_install_sanitize_config"

--- a/recipes/openresolv/openresolv_3.9.0.oe
+++ b/recipes/openresolv/openresolv_3.9.0.oe
@@ -1,0 +1,1 @@
+require ${PN}.inc

--- a/recipes/openresolv/openresolv_3.9.0.oe.sig
+++ b/recipes/openresolv/openresolv_3.9.0.oe.sig
@@ -1,0 +1,1 @@
+5ea73075f03fed30e3b8cf628bb19540897bac47  openresolv-3.9.0.tar.xz


### PR DESCRIPTION
We amend the included resolvconf.conf by disabling all hooks except
libc, since most embedded systems probably don't have the software in
question anyway, and for the libc hook we avoid doing a lot of work to
figure out how to restart a probably-not-even-existing nscd service.

The user of this recipe may of course provide his own openresolv-config
overriding all of that.