### PR TITLE
update various execline scripts

### DIFF
--- a/recipes/dhcp/files/dhcpd.run
+++ b/recipes/dhcp/files/dhcpd.run
@@ -3,13 +3,13 @@ redirfd -c 1 /run/dhcpd-log.fifo
 fdmove -c 2 1
 
 s6-envdir -I /etc/dhcp/dhcpd.env
-import -s INTERFACES
-import -D /var/lib/dhcp/dhcpd.leases LEASE_FILE
-import -D /etc/dhcp/dhcpd.conf CONFIG_FILE
+importas -s INTERFACES INTERFACES
+importas -D /var/lib/dhcp/dhcpd.leases LEASE_FILE LEASE_FILE
+importas -D /etc/dhcp/dhcpd.conf CONFIG_FILE CONFIG_FILE
 
 if {
   backtick -i -n lease_dir { dirname ${LEASE_FILE} }
-  import lease_dir
+  importas lease_dir lease_dir
   mkdir -p ${lease_dir}
 }
 if {

--- a/recipes/netbase/netbase/ifplugd.run
+++ b/recipes/netbase/netbase/ifplugd.run
@@ -2,10 +2,10 @@
 redirfd -c 1 /run/network-log.fifo
 fdmove -c 2 1
 s6-envdir -I ./env
-import -s ARGS
+importas -s ARGS ARGS
 backtick -n iface {
-  pipeline { getcwd cwd import cwd basename $cwd }
+  pipeline { getcwd cwd importas cwd cwd basename $cwd }
   sed -e "s/ifplugd@//"
 }
-import -u iface
+importas -u iface iface
 ifplugd -i $iface -n -s $ARGS -r /etc/ifplugd/ifplugd.action

--- a/recipes/netbase/netbase/net-hotplug.hook
+++ b/recipes/netbase/netbase/net-hotplug.hook
@@ -2,7 +2,7 @@
 
 elgetpositionals
 backtick -n hooksdir { dirname $0 }
-import -u hooksdir
+importas -u hooksdir hooksdir
 define basename ifplugd@
 define templatedir ${hooksdir}/${basename}.d
 if { mkdir ${1}/net-hotplug }
@@ -12,7 +12,7 @@ if { s6-echo -- "bundle" }
 fdswap 1 3
 redirfd -w 3 ${1}/net-hotplug/contents
 forbacktickx iface { hotplug-interfaces }
-import -u iface
+importas -u iface iface
 fdswap 1 3
 if { s6-echo -- "${basename}${iface}" }
 fdswap 1 3

--- a/recipes/netbase/netbase/net-udhcpc.hook
+++ b/recipes/netbase/netbase/net-udhcpc.hook
@@ -2,9 +2,9 @@
 
 elgetpositionals
 backtick -n hooksdir { dirname $0 }
-import -u hooksdir
+importas -u hooksdir hooksdir
 define basename udhcpc@
 define templatedir ${hooksdir}/${basename}.d
 forbacktickx -C -n iface { dhcp-interfaces }
-import -u iface
+importas -u iface iface
 cp -r ${templatedir}/ ${1}/${basename}${iface}/

--- a/recipes/netbase/netbase/udhcpc.run
+++ b/recipes/netbase/netbase/udhcpc.run
@@ -2,10 +2,10 @@
 redirfd -c 1 /run/network-log.fifo
 fdmove -c 2 1
 s6-envdir -I ./env
-import -s ARGS
+importas -s ARGS ARGS
 backtick -n iface {
-  pipeline { getcwd cwd import cwd basename $cwd }
+  pipeline { getcwd cwd importas cwd cwd basename $cwd }
   sed -e "s/udhcpc@//"
 }
-import -u iface
+importas -u iface iface
 udhcpc -i $iface -f $ARGS

--- a/recipes/openssh/files/openssh-keygen.up
+++ b/recipes/openssh/files/openssh-keygen.up
@@ -2,7 +2,7 @@ redirfd -c 1 /run/openssh-log.fifo
 fdmove -c 2 1
 redirfd -r 0 /etc/ssh/host_key_types
 forstdin -o 0 keytype
-import -u keytype
+importas -u keytype keytype
 ifelse { test ${keytype} = all }
 { ssh-keygen -A }
 define keyfile ssh_host_${keytype}_key

--- a/recipes/openvpn/files/openvpn.hook
+++ b/recipes/openvpn/files/openvpn.hook
@@ -2,7 +2,7 @@
 
 elgetpositionals
 backtick -n hooksdir { dirname $0 }
-import -u hooksdir
+importas -u hooksdir hooksdir
 define basename openvpn@
 define templatedir ${hooksdir}/${basename}.d
 define allbundledir ${1}/openvpn
@@ -11,8 +11,8 @@ if { redirfd -w 1 ${allbundledir}/type s6-echo "bundle" }
 if { redirfd -w 1 ${allbundledir}/contents exit 0 }
 elglob -s -0 confs /etc/openvpn/*.conf
 forx conffile { $confs }
-import -u conffile
+importas -u conffile conffile
 backtick -n name { basename ${conffile} .conf }
-import -u name
+importas -u name name
 if { cp -r ${templatedir}/ ${1}/${basename}${name}/ }
 redirfd -a 1 ${allbundledir}/contents s6-echo ${basename}${name}

--- a/recipes/openvpn/files/openvpn.run
+++ b/recipes/openvpn/files/openvpn.run
@@ -2,8 +2,8 @@
 redirfd -c 1 /run/openvpn-log.fifo
 fdmove -c 2 1
 backtick -n name {
-  pipeline { getcwd cwd import cwd basename $cwd }
+  pipeline { getcwd cwd importas cwd cwd basename $cwd }
   sed -e "s/openvpn@//"
 }
-import -u name
+importas -u name name
 openvpn --echo "Starting openvpn@${name}" --config /etc/openvpn/${name}.conf

--- a/recipes/s6-init/s6-init/hostname.up
+++ b/recipes/s6-init/s6-init/hostname.up
@@ -1,7 +1,7 @@
 ifelse { s6-test -f /etc/hostname } {
   redirfd -r 0 /etc/hostname
   withstdinas -n hostname
-  import -u hostname
+  importas -u hostname hostname
   s6-hostname ${hostname}
 }
 s6-hostname HOSTNAME

--- a/recipes/s6-init/s6-init/init-sysctl.up
+++ b/recipes/s6-init/s6-init/init-sysctl.up
@@ -1,7 +1,7 @@
 if -t { test -f /etc/sysctl.txt }
 redirfd -r 0 /etc/sysctl.txt
 forstdin -nCd"\n" -- LINE
-import -u LINE
+importas -u LINE LINE
 multidefine -C $LINE { CTL VALUE }
 redirfd -w 1 /proc/sys/$CTL
 s6-echo -- $VALUE

--- a/recipes/s6-init/s6-init/mount-cgroups.up
+++ b/recipes/s6-init/s6-init/mount-cgroups.up
@@ -5,6 +5,6 @@ pipeline { s6-tail -n +2 }
 pipeline { s6-cut -d"\t" -f1 }
 pipeline { s6-grep -vF -- devices }
 forstdin -d"\n" -- i
-import -u i
+importas -u i i
 if { mkdir /sys/fs/cgroup/${i} }
 s6-mount -t cgroup -o ${i} -- cgroup /sys/fs/cgroup/${i}

--- a/recipes/s6-init/s6-init/rtc.down
+++ b/recipes/s6-init/s6-init/rtc.down
@@ -1,25 +1,25 @@
 #!/bin/execlineb -P
 s6-envdir -I /etc/hwclock
-import -D 1 UTC
+importas -D 1 UTC UTC
 backtick -n -i utc_arg {
   ifelse { test ${UTC} = 1 }
   { s6-echo -- "-u" }
   s6-echo -- "-l"
 }
-import utc_arg
-import -D "" ADJFILE
+importas utc_arg utc_arg
+importas -D "" ADJFILE ADJFILE
 backtick -n -i adjfile_arg {
   ifelse { test -n "${ADJFILE}" }
   { s6-echo -- "--adjfile ${ADJFILE}" }
   s6-echo -- ""
 }
-import -s adjfile_arg
-import -D "" DELAY
+importas -s adjfile_arg adjfile_arg
+importas -D "" DELAY DELAY
 backtick -n -i delay_arg {
   ifelse { test -n "${DELAY}" }
   { s6-echo -- "--delay ${DELAY}" }
   s6-echo -- ""
 }
-import -s delay_arg
-import -D /dev/rtc DEVICE
+importas -s delay_arg delay_arg
+importas -D /dev/rtc DEVICE DEVICE
 hwclock -w ${utc_arg} -f ${DEVICE} ${adjfile_arg} ${delay_arg}

--- a/recipes/s6-init/s6-init/rtc.up
+++ b/recipes/s6-init/s6-init/rtc.up
@@ -1,18 +1,18 @@
 #!/bin/execlineb -P
 s6-envdir -I /etc/hwclock
-import -D 1 UTC
+importas -D 1 UTC UTC
 backtick -n -i utc_arg {
   ifelse { test ${UTC} = 1 }
   { s6-echo -- "-u" }
   s6-echo -- "-l"
 }
-import utc_arg
-import -D "" ADJFILE
+importas utc_arg utc_arg
+importas -D "" ADJFILE ADJFILE
 backtick -n -i adjfile_arg {
   ifelse { test -n "${ADJFILE}" }
   { s6-echo -- "--adjfile ${ADJFILE}" }
   s6-echo -- ""
 }
-import -s adjfile_arg
-import -D /dev/rtc DEVICE
+importas -s adjfile_arg adjfile_arg
+importas -D /dev/rtc DEVICE DEVICE
 hwclock -s ${utc_arg} -f ${DEVICE} ${adjfile_arg}

--- a/recipes/s6-init/s6-init/s6-init-compile
+++ b/recipes/s6-init/s6-init/s6-init-compile
@@ -12,7 +12,7 @@ if { mkdir -p ${hookdst}.tmp }
 if {
   elglob -s -0 hooks /etc/rc.hooks/*
   forx hook { $hooks }
-  import -u hook
+  importas -u hook hook
   if { test -f $hook -a -x $hook }
   foreground { if { test $VERBOSITY -ge 2 }
     s6-echo "Executing ${hook}" }


### PR DESCRIPTION
After the update of execline, many scripts spit out 'import: warning: the import command and directive are obsolescent, please use importas instead!'. Fix them up to use importas.

These are scripted, so please review. The github gui may do a decent job of highlighting the relevant parts of the lines, but another good way to see the changes are with
```
git diff --word-diff=color --word-diff-regex='.' master..
```
