### PR TITLE
lttng-modules: fix compilation against 4.14-rt kernels

### DIFF
--- a/recipes/lttng/lttng-modules/0001-Fix-update-timer-instrumentation-on-4.16-and-4.14-rt.patch
+++ b/recipes/lttng/lttng-modules/0001-Fix-update-timer-instrumentation-on-4.16-and-4.14-rt.patch
@@ -1,0 +1,85 @@
+From 562860aa5d13249d2c80e51080a3437ef5d2fe0b Mon Sep 17 00:00:00 2001
+From: Rasmus Villemoes <rasmus.villemoes@prevas.dk>
+Date: Mon, 12 Feb 2018 18:31:40 +0100
+Subject: [PATCH] Fix: update timer instrumentation on 4.16 and 4.14-rt
+
+See upstream commit :
+
+  commit 63e2ed3659752a4850e0ef3a07f809988fcd74a4
+  Author: Anna-Maria Gleixner <anna-maria@linutronix.de>
+  Date:   Thu Dec 21 11:41:38 2017 +0100
+
+    tracing/hrtimer: Print the hrtimer mode in the 'hrtimer_start' tracepoint
+
+    The 'hrtimer_start' tracepoint lacks the mode information. The mode is
+    important because consecutive starts can switch from ABS to REL or from
+    PINNED to non PINNED.
+
+    Append the mode field.
+
+See linux-rt commit :
+
+  commit 6ee32a49b1ed61c08ac9f1c9fcbf83d3c749b71d
+  Author: Anna-Maria Gleixner <anna-maria@linutronix.de>
+  Date:   Sun Oct 22 23:39:46 2017 +0200
+
+    tracing: hrtimer: Print hrtimer mode in hrtimer_start tracepoint
+
+    The hrtimer_start tracepoint lacks the mode information. The mode is
+    important because consecutive starts can switch from ABS to REL or from
+    PINNED to non PINNED.
+
+    Add the mode information.
+
+Signed-off-by: Rasmus Villemoes <rasmus.villemoes@prevas.dk>
+Signed-off-by: Michael Jeanson <mjeanson@efficios.com>
+Signed-off-by: Mathieu Desnoyers <mathieu.desnoyers@efficios.com>
+---
+Upstream-status: Accepted (as 8c7865d in stable-2.10 branch, 562860a in master)
+
+ instrumentation/events/lttng-module/timer.h | 22 ++++++++++++++++++++++
+ 1 file changed, 22 insertions(+)
+
+diff --git a/instrumentation/events/lttng-module/timer.h b/instrumentation/events/lttng-module/timer.h
+index d62fd25..6f0cb7f 100644
+--- a/instrumentation/events/lttng-module/timer.h
++++ b/instrumentation/events/lttng-module/timer.h
+@@ -160,6 +160,27 @@ LTTNG_TRACEPOINT_EVENT_MAP(hrtimer_init,
+  * hrtimer_start - called when the hrtimer is started
+  * @timer: pointer to struct hrtimer
+  */
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4,16,0) || \
++	LTTNG_RT_KERNEL_RANGE(4,14,0,0, 4,15,0,0))
++LTTNG_TRACEPOINT_EVENT_MAP(hrtimer_start,
++
++	timer_hrtimer_start,
++
++	TP_PROTO(struct hrtimer *hrtimer, enum hrtimer_mode mode),
++
++	TP_ARGS(hrtimer, mode),
++
++	TP_FIELDS(
++		ctf_integer_hex(void *, hrtimer, hrtimer)
++		ctf_integer_hex(void *, function, hrtimer->function)
++		ctf_integer(s64, expires,
++			lttng_ktime_get_tv64(hrtimer_get_expires(hrtimer)))
++		ctf_integer(s64, softexpires,
++			lttng_ktime_get_tv64(hrtimer_get_softexpires(hrtimer)))
++		ctf_integer(enum hrtimer_mode, mode, mode)
++	)
++)
++#else
+ LTTNG_TRACEPOINT_EVENT_MAP(hrtimer_start,
+ 
+ 	timer_hrtimer_start,
+@@ -177,6 +198,7 @@ LTTNG_TRACEPOINT_EVENT_MAP(hrtimer_start,
+ 			lttng_ktime_get_tv64(hrtimer_get_softexpires(hrtimer)))
+ 	)
+ )
++#endif
+ 
+ /**
+  * htimmer_expire_entry - called immediately before the hrtimer callback
+-- 
+2.15.1
+

--- a/recipes/lttng/lttng-modules_2.10.4.oe
+++ b/recipes/lttng/lttng-modules_2.10.4.oe
@@ -1,1 +1,3 @@
 require ${PN}.inc
+# Not needed for 2.10.6+ nor 2.11+.
+SRC_URI += "file://0001-Fix-update-timer-instrumentation-on-4.16-and-4.14-rt.patch"


### PR DESCRIPTION
We can drop this patch when 2.10.6 comes out, but for now I need this.