### PR TITLE
openssh: allow default ssh session PATH to be set via USE flags

### DIFF
--- a/recipes/openssh/openssh.inc
+++ b/recipes/openssh/openssh.inc
@@ -42,6 +42,10 @@ EXTRA_OECONF = "--disable-suid-ssh --with-ssl \
 
 EXTRA_OEMAKE = "'STRIP_OPT='"
 
+RECIPE_FLAGS += "openssh_default_path openssh_superuser_path"
+EXTRA_OECONF:>USE_openssh_default_path = " --with-default-path=${USE_openssh_default_path}"
+EXTRA_OECONF:>USE_openssh_superuser_path = " --with-superuser-path=${USE_openssh_superuser_path}"
+
 do_patch[postfuncs] += "do_patch_aclocal_mangle"
 do_patch_aclocal_mangle () {
 	if [ ! -e acinclude.m4 -a -e aclocal.m4 ]; then


### PR DESCRIPTION
By default, openssh set a PATH of /usr/bin:/bin:/usr/sbin:/sbin for a
new session. This is different from the default busybox value of
/sbin:/usr/sbin:/bin:/usr/bin .

The value used by openssh can be set at configure time with the
--with-default-path option, and if a different value is required for
uid 0, --with-superuser-path. We can easily allow e.g. the distro to
set these values by providing USE flags for them, the absence of which
will just keep the current behaviour.