### PR TITLE
s6-init: Allow blocking mode to service command

### DIFF
--- a/recipes/s6-init/s6-init/service
+++ b/recipes/s6-init/s6-init/service
@@ -2,19 +2,21 @@
 
 usage() {
     cat <<EOF
-usage: $0 start <service>...
-       $0 stop <service>...
-       $0 restart <service>...
-       $0 status [<service>]
+usage: $0 [-b] start <service>...
+       $0 [-b] stop <service>...
+       $0 [-b] restart <service>...
+       $0 [-b] status [<service>]
 EOF
-    }
+}
+
+blocking=
 
 start() {
-    s6-rc -u -t 10000 change $*
+    s6-rc $blocking -u -t 10000 change $*
 }
 
 stop() {
-    s6-rc -d -t 10000 change $*
+    s6-rc $blocking -d -t 10000 change $*
 }
 
 if test -t 1 ; then
@@ -39,7 +41,7 @@ status_all() {
     t=`mktemp`
     up=""
     down=""
-    for srv in `s6-rc -a list` ; do
+    for srv in `s6-rc $blocking -a list` ; do
 	test "$srv" = "s6rc-oneshot-runner" && continue
 	test "$srv" = "s6rc-fdholder" && continue
 	if [ ${#srv} -gt $srvmaxlen ] ; then
@@ -47,7 +49,7 @@ status_all() {
 	fi
 	up="$up $srv"
     done
-    for srv in `s6-rc -da list` ; do
+    for srv in `s6-rc $blocking -da list` ; do
 	test "$srv" = "s6rc-oneshot-runner" && continue
 	test "$srv" = "s6rc-fdholder" && continue
 	if [ ${#srv} -gt $srvmaxlen ] ; then
@@ -66,13 +68,13 @@ status_all() {
 }
 
 status_one() {
-    for srv in `s6-rc -a list` ; do
+    for srv in `s6-rc $blocking -a list` ; do
 	if [ "$srv" = "$1" ] ; then
 	    echo "$1 is up"
 	    return 0
 	fi
     done
-    for srv in `s6-rc -da list` ; do
+    for srv in `s6-rc $blocking -da list` ; do
 	if [ "$srv" = "$1" ] ; then
 	    echo "$1 is down"
 	    return 1
@@ -81,6 +83,11 @@ status_one() {
     echo "$1 is unknown"
     return 3
 }
+
+if [ "$1" = "-b" ] ; then
+    blocking="-b"
+    shift
+fi
 
 if [ $# -lt 1 ] ; then
     usage


### PR DESCRIPTION
Adding a '-b' option to service command allows blocking on the s6-rc lock
starting and stopping services.  Without this, service command fails when
called while another (s6-rc) program holds the lock, spewing error messages
like

    s6-rc: fatal: unable to take locks: Resource temporarily unavailable

This is generally the safe approach, so it is kept as the default.

But when using service command while changing s6-rc state (for example during
boot), it can be convenient to wait for the s6-rc lock to be released.

A valid use-case is when an application (that is not running as an s6-rc
service!) wants to stop an s6-rc service.  To avoid failure when started
during boot, the -b option is very helpful.

Note: The -b option must not be used in nested s6-rc invocation.  Anything
running with the the s6-rc lock held (for example an s6-rc service script)
will deadlock forever if using service command with -b option!

Signed-off-by: Esben Haabendal <esben@haabendal.dk>