### PR TITLE
mobile-broadband-provider-info: Fix source SHA1 signature

### DIFF
--- a/recipes/mobile-broadband-provider-info/mobile-broadband-provider-info_20151214.oe.sig
+++ b/recipes/mobile-broadband-provider-info/mobile-broadband-provider-info_20151214.oe.sig
@@ -1,1 +1,1 @@
-240590ce5b8dfff91a3e0a08ef7437662613a037  mobile-broadband-provider-info-20151214.tar.xz
+4457b1afa262cd707cd601b1f96024999445b450  mobile-broadband-provider-info-20151214.tar.xz


### PR DESCRIPTION
This fixes the sha1sum to match the publically announced sha1sum, which
incidentally matches all the tarballs out there.  It is also the same
signature that other projects uses.

I don't have a copy of the old tarball, so I cannot see what has changed.

Signed-off-by: Esben Haabendal <esben@haabendal.dk>