### PR TITLE
fastcgi: Fix library header packaging

### DIFF
--- a/recipes/fastcgi/fastcgi.inc
+++ b/recipes/fastcgi/fastcgi.inc
@@ -9,3 +9,4 @@ S= "${SRCDIR}/fcgi-${PV}"
 
 AUTO_PACKAGE_UTILS = "cgi-fcgi"
 AUTO_PACKAGE_LIBS = "fcgi"
+FILES_${PN}-libfcgi-dev = "${includedir}"


### PR DESCRIPTION
Include the header files directly in the fastcgi-libfcgi-dev package,
so they are always included in SDK together with libfcgi.

Signed-off-by: Esben Haabendal <esben@haabendal.dk>