### PR TITLE
lmsensors: Fix library header packaging

### DIFF
--- a/recipes/lmsensors/lmsensors.inc
+++ b/recipes/lmsensors/lmsensors.inc
@@ -54,6 +54,7 @@ FILES_${PN}-config = "${sysconfdir}"
 RDEPENDS_${PN}-sensors += "${PN}-config"
 
 AUTO_PACKAGE_LIBS = "sensors"
+FILES_${PN}-libsensors-dev = "${includedir}"
 DEPENDS_${PN}-libsensors += "libc libm"
 RDEPENDS_${PN}-libsensors += "libc libm"
 


### PR DESCRIPTION
Include the header files directly in the lmsensors-libsensors-dev package,
so they are always included in SDK together with libsensors.

Signed-off-by: Esben Haabendal <esben@haabendal.dk>