### PR TITLE
Mirrors append

### DIFF
--- a/recipes/lftp/lftp.inc
+++ b/recipes/lftp/lftp.inc
@@ -20,7 +20,7 @@ SRC_URI = "${LFTP_MIRROR}/lftp-${PV}.tar.bz2"
 SRC_URI += "file://config.site"
 SRC_HOST_SITEFILES = "${SRCDIR}/config.site"
 
-MIRRORS = """
+MIRRORS += """
 ${LFTP_MIRROR} ${LFTP_MIRROR}/old
 ${LFTP_MIRROR} http://lftp.cybermirror.org
 ${LFTP_MIRROR} http://lftp.cybermirror.org/old

--- a/recipes/splashutils/splashutils.inc
+++ b/recipes/splashutils/splashutils.inc
@@ -60,6 +60,6 @@ do_install_cachedir () {
 do_install[postfuncs] += "do_install_cachedir"
 FILES_${PN}-fbsplashctl += "${base_libdir}/splash/cache"
 
-MIRRORS = """
+MIRRORS += """
 http://fbsplash.alanhaggai.org/tarballs/files http://sourceforge.net/projects/fbsplash.berlios/files/
 """


### PR DESCRIPTION
Otherwise, default MIRRORS settings are overwritten, causing problems if/when upstream mirrors stop
hosting the files.