### PR TITLE
wget: Fix build on hosts with libz and pkg-config

### DIFF
--- a/recipes/wget/wget.inc
+++ b/recipes/wget/wget.inc
@@ -7,7 +7,7 @@ DEPENDS_LIBC = "librt"
 DEPENDS_LIBC:HOST_LIBC_mingw = ""
 DEPENDS = "${DEPENDS_LIBC} native:flex"
 
-inherit autotools gettext
+inherit autotools gettext pkgconfig
 
 #Only used for Aarch64
 AUTOCONFDIRS = "/build-aux"


### PR DESCRIPTION
As wget reverts to using pkg-config to find library and linker flags for
linking with libz, we need to ensure that we access the real pkg-config
data.

Without this, we can end up searching something like
/usr/lib/x86_64-linux-gnu/ for target libraries, which obviously does
not work very well.

Signed-off-by: Esben Haabendal <esben@haabendal.dk>