### PR TITLE
ppp: Backport fix for build problem with newish linux-headers

### DIFF
--- a/recipes/ppp/files/in-h-header-sync.patch
+++ b/recipes/ppp/files/in-h-header-sync.patch
@@ -1,0 +1,46 @@
+commit 50a2997b256e0e0ef7a46fae133f56f60fce539c
+Author: Lubomir Rintel <lkundrak@v3.sk>
+Date:   Mon Jan 9 13:34:23 2017 +0000
+
+    pppoe: include netinet/in.h before linux/in.h
+    
+    This fixes builds with newer kernels. Basically, <netinet/in.h> needs to be
+    included before <linux/in.h> otherwise the earlier, unaware of the latter,
+    tries to redefine symbols and structures. Also, <linux/if_pppox.h> doesn't work
+    alone anymore, since it pulls the headers in the wrong order, so we better
+    include <netinet/in.h> early.
+
+Upstream-Status: Backport
+
+diff --git a/pppd/plugins/rp-pppoe/pppoe.h b/pppd/plugins/rp-pppoe/pppoe.h
+index 9ab2eee3914c..c4aaa6e68856 100644
+--- a/pppd/plugins/rp-pppoe/pppoe.h
++++ b/pppd/plugins/rp-pppoe/pppoe.h
+@@ -47,6 +47,10 @@
+ #include <sys/socket.h>
+ #endif
+ 
++/* This has to be included before Linux 4.8's linux/in.h
++ * gets dragged in. */
++#include <netinet/in.h>
++
+ /* Ugly header files on some Linux boxes... */
+ #if defined(HAVE_LINUX_IF_H)
+ #include <linux/if.h>
+@@ -84,8 +88,6 @@ typedef unsigned long UINT32_t;
+ #include <linux/if_ether.h>
+ #endif
+ 
+-#include <netinet/in.h>
+-
+ #ifdef HAVE_NETINET_IF_ETHER_H
+ #include <sys/types.h>
+ 
+@@ -98,7 +100,6 @@ typedef unsigned long UINT32_t;
+ #endif
+ 
+ 
+-
+ /* Ethernet frame types according to RFC 2516 */
+ #define ETH_PPPOE_DISCOVERY 0x8863
+ #define ETH_PPPOE_SESSION   0x8864

--- a/recipes/ppp/ppp.inc
+++ b/recipes/ppp/ppp.inc
@@ -20,6 +20,7 @@ SRC_URI = "https://download.samba.org/pub/ppp/ppp-${PV}.tar.gz \
            file://0001-ppp-Fix-compilation-errors-in-Makefile.patch \
            file://fix-CVE-2015-3310.patch \
            file://0001-Fix-build-with-musl.patch \
+           file://in-h-header-sync.patch \
            "
 COMPATIBLE_HOST_ARCHS = ".*linux"
 


### PR DESCRIPTION
Backport from https://github.com/paulusmack/ppp, which seems to be the current upstream.
But no releases since 2014 (2.4.7), so maybe we should start building from master branch
instead.