### PR TITLE
iw: Fix version.sh for old iw 3.7

### DIFF
--- a/recipes/iw/iw_3.7.oe
+++ b/recipes/iw/iw_3.7.oe
@@ -1,1 +1,2 @@
 require iw.inc
+SRC_URI += "file://fix_version.patch"


### PR DESCRIPTION
This patch was dropped when 3.15 was added (commit
cf3646b080f213f958509cdfa769ca9246c2f9ff).  It is not needed for 3.15,
but is still needed for 3.7, depending on the exact build setup.

When TMPDIR is relative to manifest, this fix avoids picking up the git
version information from the manifest.

Signed-off-by: Esben Haabendal <esben@haabendal.dk>